### PR TITLE
POST /conversions/documents with scrutinize: "diff2"

### DIFF
--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -254,6 +254,7 @@ POST /conversions/documents
 - **`file`** (multipart) **OR** `pdf_dataurl` (base64) — the PDF data.  
 - **`model`** (string, optional) — fallback LLM if OCR confidence is low or if boundary detection is needed.  
 - **`ocr_threshold`** (float, optional) — threshold for deciding fallback (default: `0.7`).  
+- **`scrutinize`** (string, optional) - Specify a method to scrutinize the image text.  (default: "none")
 - **`page_numbering`** (string, optional) — `"true"` or `"false"` (default: `"true"`)  
 - **`description`, `intent`, `graphic_instructions`** (optional) — context strings for fallback model.  
 - **`detect_document_boundaries`** (string, optional) — `"true"` or `"false"` (default: `"false"`)  

--- a/lib/scrutinize.mjs
+++ b/lib/scrutinize.mjs
@@ -168,40 +168,34 @@ function parseText(txt) {
 
 
 /** Render markup from Diff2 analysis.
+ *
+ * Example of markup for diff2 derived data:
+ *
+ *   Testing via <ocr var="0">CAPN1</ocr><ocr var="1">CAPN10</ocr> gene sequencing.
  */
 function renderMarkupDiff2(alignment, txtA, offsetsA, txtB, offsetsB) {
     const markup = [];
     
-    /*console.log({"event": "starting renderMarkup",
-        "tokenA0":txtA.slice(0,offsetsA[0]),
-        "tokenA1":txtA.slice(offsetsA[0],offsetsA[1]),
-        "tokenB0":txtB.slice(0,offsetsB[0]),
-        "tokenB1":txtB.slice(offsetsB[0],offsetsB[1])
-    })*/
     let ichAPrev=0;
     let ichBPrev=0;
     for (let [op, tokA, idxA, tokB, idxB] of alignment) {
         idxA += 1
         idxB += 1
-        //console.log({"event":"processing", op, tokA, idxA, tokB, idxB})
         if (op === 'MATCH') {
             const ichA = offsetsA[idxA]
             const stA = txtA.slice(ichAPrev,ichA)
             markup.push(stA)
-            //console.log({"event":"match",ichAPrev, ichA, stA})
             ichAPrev = offsetsA[idxA]
             ichBPrev = offsetsB[idxB]
         } else if (op === 'INSERT') {
             const ichB = offsetsB[idxB]
             const stB = txtB.slice(ichBPrev,ichB)
             markup.push(`<ocr var="1">${stB}</ocr>`)
-            //console.log({"event":"insert",ichBPrev, ichB, stB})
             ichBPrev = offsetsB[idxB]
         } else if (op === 'DELETE') {
             const ichA = offsetsA[idxA]
             const stA = txtA.slice(ichAPrev,ichA)
             markup.push(`<ocr var="0">${stA}</ocr>`)
-            //console.log({"event":"delete",ichAPrev, ichA, stA})
             ichAPrev = offsetsA[idxA]
         }
     }
@@ -220,8 +214,18 @@ export function scrutinizeViaDiff2(texts) {
 
     let alignment = computeAlignmentDiff2(tokensA, tokensB);
     alignment = removeWhitespaceDiff2(alignment);
-    // TODO: pass offsets to the pre-normalized text
     const markup = renderMarkupDiff2(alignment, texts[0], offsetsA, texts[1], offsetsB);
   
     return markup
 }
+
+/** TODO: OCR-prompt-based scrutinization
+ *
+ * This method requires only one LLM pass.
+ *
+ * The following example shows the expected format for OCR-prompt-based scrutinization.
+ *
+ * Example of markup for OCR-prompt scrutinization:
+ *
+ *   Testing via <ocr var="?">CAPN1</ocr> gene sequencing.
+ */

--- a/lib/scrutinize.mjs
+++ b/lib/scrutinize.mjs
@@ -1,0 +1,168 @@
+
+
+// begin code from test_confusion_transcription_2.mjs
+
+// ----------------------------------------------------------------------------
+// 3) Longest Common Subsequence alignment utility
+// ----------------------------------------------------------------------------
+/**
+ * Computes a standard LCS for two arrays of tokens, seqA and seqB.
+ * Returns a list of alignment instructions:
+ *   - ["MATCH",  tokenA, idxA, tokenB, idxB]
+ *   - ["INSERT", null,   null,  tokenB, idxB]   (the tokenB was inserted)
+ *   - ["DELETE", tokenA, idxA,  null,   null]   (the tokenA was deleted)
+ *
+ * @param {string[]} seqA
+ * @param {string[]} seqB
+ * @returns {Array}
+ */
+function computeAlignmentDiff2(seqA, seqB) {
+    const lenA = seqA.length;
+    const lenB = seqB.length;
+  
+    // dp[i][j] = LCS length for seqA[:i], seqB[:j]
+    const dp = [];
+    for (let i = 0; i <= lenA; i++) {
+      dp.push(new Array(lenB + 1).fill(0));
+    }
+  
+    for (let i = 1; i <= lenA; i++) {
+      for (let j = 1; j <= lenB; j++) {
+        if (seqA[i - 1] === seqB[j - 1]) {
+          dp[i][j] = dp[i - 1][j - 1] + 1;
+        } else {
+          dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+        }
+      }
+    }
+  
+    // Backtrack to retrieve alignment
+    const alignment = [];
+    let i = lenA;
+    let j = lenB;
+    while (i > 0 || j > 0) {
+      if (i > 0 && j > 0 && seqA[i - 1] === seqB[j - 1]) {
+        alignment.push(["MATCH", seqA[i - 1], i - 1, seqB[j - 1], j - 1]);
+        i -= 1;
+        j -= 1;
+      } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+        // insertion in seqB
+        alignment.push(["INSERT", null, null, seqB[j - 1], j - 1]);
+        j -= 1;
+      } else {
+        // deletion from seqA
+        alignment.push(["DELETE", seqA[i - 1], i - 1, null, null]);
+        i -= 1;
+      }
+    }
+    alignment.reverse();
+    return alignment;
+  }
+  
+  // ----------------------------------------------------------------------------
+  // 4) Text normalization and "UNCLEAR" handling
+  // ----------------------------------------------------------------------------
+  
+  const reNorm1 = /[`‘’]/g;
+  
+  /**
+   * Normalize tokens by converting to lowercase and substituting certain quotes with `'`.
+   * @param {string[]} toks
+   * @returns {string[]}
+   */
+  function normalizeTokens(toks) {
+    return toks.map(tok => tok.replace(reNorm1, "'").toLowerCase());
+  }
+  
+  function parseText(txt) {
+    return normalizeTokens(txt.split(/\s+/));
+  }  
+
+  // parseGroundTruthText, parsePredictedTextWithUnclear
+  // . . .
+  
+  // ----------------------------------------------------------------------------
+  // 5) Utility to remove whitespace-only diffs
+  // ----------------------------------------------------------------------------
+  /**
+   * Given a list of diff tuples, remove any DELETE + consecutive INSERT blocks
+   * where the only real difference is that one token was split by whitespace.
+   *
+   * @param {Array} diffs  e.g. [ ["DELETE", "c.6304t>g,", 83, null, null], ...]
+   * @returns {Array}
+   */
+  function removeWhitespaceDiff2(diffs) {
+    const result = [];
+    let i = 0;
+    const n = diffs.length;
+  
+    while (i < n) {
+      const current = diffs[i];
+  
+      // Look for a single DELETE whose text might have been split incorrectly
+      if (current[0] === 'DELETE' && current[1] != null) {
+        const oldText = current[1];
+  
+        // Gather consecutive INSERTs
+        let j = i + 1;
+        const insertedTokens = [];
+        while (j < n && diffs[j][0] === 'INSERT') {
+          insertedTokens.push(diffs[j][3]);
+          j++;
+        }
+  
+        // Compare concatenated INSERT tokens to the DELETE text
+        if (insertedTokens.join('') === oldText) {
+          // It's a pure whitespace-split difference; skip these lines
+          i = j;
+          continue;
+        } else {
+          // Not a whitespace difference, so keep it
+          result.push(current);
+          i++;
+        }
+      } else {
+        result.push(current);
+        i++;
+      }
+    }
+    return result;
+  }
+
+// end code from test_confusion_transcription_2.mjs
+
+
+/* Render markup from Diff2 analysis.
+*/
+function renderMarkupDiff2(alignment) {
+    const markup = [];
+    
+    for (const [op, tokA, idxA, tokB, idxB] of alignment) {
+        if (op === 'MATCH') {
+            
+        } else if (op === 'INSERT') {
+            
+        } else if (op === 'DELETE') {
+            
+        }
+    }
+    
+    return markup;
+}
+  
+
+
+export function scrutinizeViaDiff2(texts) {
+    assert(texts && texts.length==2)
+
+    // TODO: retain offsets to the pre-normalized text
+    const tokens1 = parseText(texts[0]);
+    const tokens2 = parseText(texts[1]);
+
+    let alignment = computeAlignmentDiff2(tokens1, tokens2);
+    alignment = removeWhitespaceDiff2(alignment);
+    // TODO: pass offsets to the pre-normalized text
+    const markup = renderMarkupDiff2(alignment);
+  
+    return markup
+}

--- a/lib/scrutinize.mjs
+++ b/lib/scrutinize.mjs
@@ -60,7 +60,11 @@ function computeAlignmentDiff2(seqA, seqB) {
   }
   
   // ----------------------------------------------------------------------------
-  // 4) Text normalization and "UNCLEAR" handling
+  // 4) Text normalization
+  //
+  // All text normalization preserves character count so that scruninization
+  // can be on the basis of significant characters, and formatting characters
+  // can pass through.
   // ----------------------------------------------------------------------------
   
   const reNorm1 = /[`‘’]/g;
@@ -73,22 +77,53 @@ function computeAlignmentDiff2(seqA, seqB) {
   function normalizeTokens(toks) {
     return toks.map(tok => tok.replace(reNorm1, "'").toLowerCase());
   }
-  
-  function parseText(txt) {
-    return normalizeTokens(txt.split(/\s+/));
-  }  
+
+/**
+* Split and normalize incoming text into token words, preserving original offsets.
+* @param {string} txt, incoming text
+* @returns {Tuple[Array[String],Array[number]]} with matching lengths
+*/
+function parseText(txt) {
+    let words = [];
+    const offsets = [];
+
+    // Use a regex exec loop to find each word and its index
+    const re = /\S+/g;
+    let match;
+    let ichEnd = 0;
+    while ((match = re.exec(txt)) !== null) {
+        if(words.length==0 && match.index>0) {
+        }
+        words.push(match[0]);
+        offsets.push(match.index);
+        ichEnd = match.index + match.length
+    }
+    // Always end with a whitespace token, even if empty
+    words.push(txt.slice(ichEnd, txt.length))
+    offsets.push(ichEnd)
+
+    // Normalize the tokens but retain the offsets
+    words = normalizeTokens(words);
+
+    return [words, offsets];
+}
 
   // parseGroundTruthText, parsePredictedTextWithUnclear
   // . . .
   
-  // ----------------------------------------------------------------------------
-  // 5) Utility to remove whitespace-only diffs
-  // ----------------------------------------------------------------------------
+
   /**
+   * Remove diffs due to nondeterministic detection of whitespace.
+   *
    * Given a list of diff tuples, remove any DELETE + consecutive INSERT blocks
    * where the only real difference is that one token was split by whitespace.
    *
-   * @param {Array} diffs  e.g. [ ["DELETE", "c.6304t>g,", 83, null, null], ...]
+   *   Example: remove this:
+   *     ['DELETE', 'c.6304T>G,', 83, None, None]
+   *     ['INSERT', None, None, 'c.6304T', 83]
+   *     ['INSERT', None, None, '>', 84]
+   *     ['INSERT', None, None, 'G,', 85]
+   * @param {Array} diffs
    * @returns {Array}
    */
   function removeWhitespaceDiff2(diffs) {
@@ -132,37 +167,61 @@ function computeAlignmentDiff2(seqA, seqB) {
 // end code from test_confusion_transcription_2.mjs
 
 
-/* Render markup from Diff2 analysis.
-*/
-function renderMarkupDiff2(alignment) {
+/** Render markup from Diff2 analysis.
+ */
+function renderMarkupDiff2(alignment, txtA, offsetsA, txtB, offsetsB) {
     const markup = [];
     
-    for (const [op, tokA, idxA, tokB, idxB] of alignment) {
+    /*console.log({"event": "starting renderMarkup",
+        "tokenA0":txtA.slice(0,offsetsA[0]),
+        "tokenA1":txtA.slice(offsetsA[0],offsetsA[1]),
+        "tokenB0":txtB.slice(0,offsetsB[0]),
+        "tokenB1":txtB.slice(offsetsB[0],offsetsB[1])
+    })*/
+    let ichAPrev=0;
+    let ichBPrev=0;
+    for (let [op, tokA, idxA, tokB, idxB] of alignment) {
+        idxA += 1
+        idxB += 1
+        //console.log({"event":"processing", op, tokA, idxA, tokB, idxB})
         if (op === 'MATCH') {
-            
+            const ichA = offsetsA[idxA]
+            const stA = txtA.slice(ichAPrev,ichA)
+            markup.push(stA)
+            //console.log({"event":"match",ichAPrev, ichA, stA})
+            ichAPrev = offsetsA[idxA]
+            ichBPrev = offsetsB[idxB]
         } else if (op === 'INSERT') {
-            
+            const ichB = offsetsB[idxB]
+            const stB = txtB.slice(ichBPrev,ichB)
+            markup.push(`<ocr var="1">${stB}</ocr>`)
+            //console.log({"event":"insert",ichBPrev, ichB, stB})
+            ichBPrev = offsetsB[idxB]
         } else if (op === 'DELETE') {
-            
+            const ichA = offsetsA[idxA]
+            const stA = txtA.slice(ichAPrev,ichA)
+            markup.push(`<ocr var="0">${stA}</ocr>`)
+            //console.log({"event":"delete",ichAPrev, ichA, stA})
+            ichAPrev = offsetsA[idxA]
         }
     }
     
-    return markup;
+    return markup.join("");
 }
   
 
 
 export function scrutinizeViaDiff2(texts) {
-    assert(texts && texts.length==2)
+    console.assert(texts && texts.length==2)
 
-    // TODO: retain offsets to the pre-normalized text
-    const tokens1 = parseText(texts[0]);
-    const tokens2 = parseText(texts[1]);
+    // retain offsets to the pre-normalized text
+    const [tokensA,offsetsA] = parseText(texts[0]);
+    const [tokensB,offsetsB] = parseText(texts[1]);
 
-    let alignment = computeAlignmentDiff2(tokens1, tokens2);
+    let alignment = computeAlignmentDiff2(tokensA, tokensB);
     alignment = removeWhitespaceDiff2(alignment);
     // TODO: pass offsets to the pre-normalized text
-    const markup = renderMarkupDiff2(alignment);
+    const markup = renderMarkupDiff2(alignment, texts[0], offsetsA, texts[1], offsetsB);
   
     return markup
 }

--- a/public/document.html
+++ b/public/document.html
@@ -194,6 +194,14 @@
       <textarea id="graphicInstructionsInput" rows="3" placeholder="Extra instructions for charts/figures"></textarea>
     </div>
 
+    <div class="option-item">
+      <label for="scrutinize">Scrutinize method</label>
+      <select id="scrutinize">
+        <option value="none" selected>none</option>
+        <option value="diff2">Two way comparison</option>
+      </select>
+    </div>
+
     <!-- File upload area (PDF) -->
     <div style="width: 100%; margin-top:10px;">
       <label style="font-weight:600; display:block; margin-bottom:5px;">File to convert (.pdf)</label>
@@ -314,6 +322,11 @@
       <div style="display:flex; flex-direction:column; width:220px;">
         <label for="mergeSummariesGuidanceInput"><b>Merge Summaries Guidance</b></label>
         <textarea id="mergeSummariesGuidanceInput" rows="3" placeholder="How to combine chunk-level summaries?"></textarea>
+      </div>
+
+      <div class="option-item">
+        <label for="scrutinize">scrutinize</label>
+        <input type="string" id="scrutinize" value="none">
       </div>
     </div>
 
@@ -630,6 +643,7 @@
       formData.append('file', uploadedFile);
       formData.append('model', modelSelect.value);
       formData.append('ocr_threshold', ocrThresholdInput.value);
+      formData.append('scrutinize', scrutinize.value);
       formData.append('page_numbering', pageNumberingSelect.value);
       formData.append('detect_document_boundaries', detectBoundariesSelect.value);
       formData.append('describe', describeSelect.value);

--- a/routes/charmonizer/document-conversion.mjs
+++ b/routes/charmonizer/document-conversion.mjs
@@ -114,6 +114,7 @@ const router = express.Router();
  *  - "pdf_dataurl" if uploading inline base64 for a PDF
  *  - "model" => fallback LLM
  *  - "ocr_threshold" => numeric, default=0.7
+ *  - "scrutinize" => string, default="none"
  *  - "page_numbering" => string "true" or "false", default "true"
  *  - "description" => optional, for passing to the fallback vision model
  *  - "intent" => optional, for passing to the fallback vision model
@@ -130,6 +131,7 @@ router.post('/documents', upload.single('file'), async (req, res) => {
   try {
     const {
       ocr_threshold = 0.7,
+      scrutinize = "none",
       model = null,
       page_numbering = 'true',
       description,
@@ -194,6 +196,7 @@ router.post('/documents', upload.single('file'), async (req, res) => {
     const jobRec = createJobRecord({
       fileBuffer,
       ocr_threshold: parseFloat(ocr_threshold),
+      scrutinize: scrutinize,
       model,
       page_numbering: String(page_numbering).toLowerCase() === 'true',
       fileMimetype: originalMimetype,

--- a/routes/charmonizer/document-conversion.mjs
+++ b/routes/charmonizer/document-conversion.mjs
@@ -13,6 +13,7 @@ import pdfParse from 'pdf-parse';
 
 // For fallback LLM-based extraction:
 import { imageToMarkdown } from '../../lib/core.mjs';
+import { scrutinizeViaDiff2 } from '../../lib/scrutinize.mjs';
 
 /**
  * We'll store job data in memory for demonstration.
@@ -54,28 +55,57 @@ async function fallbackVisionModel(imageBuffer, modelName, jobRec, precedingData
   const base64 = imageBuffer.toString('base64');
   const dataUrl = `data:image/png;base64,${base64}`;
 
-  // We'll call imageToMarkdown, optionally passing preceding_image_url, describe, and tags.
-  // That call can return { markdown, isFirstPage, description?, tags? }
-  const result = await imageToMarkdown({
-    imageUrl: dataUrl,
-    preceding_image_url: precedingDataUrl || '',
-    model: modelName,
-    description: jobRec.description || 'A document page with text and possibly diagrams.',
-    intent: jobRec.intent || 'The intended use of this transcription is not specified, so be as precise as possible.',
-    graphic_instructions: jobRec.graphic_instructions,
-    describe: jobRec.describe,
-    tags: jobRec.tags
-  });
+  if(jobRec.scrutinize == 'none') {
+    // We'll call imageToMarkdown, optionally passing preceding_image_url, describe, and tags.
+    // That call can return { markdown, isFirstPage, description?, tags? }
+    const result = await imageToMarkdown({
+      imageUrl: dataUrl,
+      preceding_image_url: precedingDataUrl || '',
+      model: modelName,
+      description: jobRec.description || 'A document page with text and possibly diagrams.',
+      intent: jobRec.intent || 'The intended use of this transcription is not specified, so be as precise as possible.',
+      graphic_instructions: jobRec.graphic_instructions,
+      describe: jobRec.describe,
+      tags: jobRec.tags
+    });
 
-  return {
-    // The main text from the fallback LLM:
-    markdown: result.markdown || '(No fallback output)',
-    isFirstPage: !!result.isFirstPage,
-    // If describe=true was given, we might get a short description
-    description: result.description || '',
-    // If tags were provided and matched, we might get them
-    tags: result.tags || []
-  };
+    return {
+      // The main text from the fallback LLM:
+      markdown: result.markdown || '(No fallback output)',
+      isFirstPage: !!result.isFirstPage,
+      // If describe=true was given, we might get a short description
+      description: result.description || '',
+      // If tags were provided and matched, we might get them
+      tags: result.tags || []
+    };
+  } else if(jobRec.scrutinize == 'diff2') {
+    const results = [];
+    for (let i = 0; i < 2; i++) {
+      const result = await imageToMarkdown({
+        imageUrl: dataUrl,
+        preceding_image_url: precedingDataUrl || '',
+        model: modelName,
+        description: jobRec.description || 'A document page with text and possibly diagrams.',
+        intent: jobRec.intent || 'The intended use of this transcription is not specified, so be as precise as possible.',
+        graphic_instructions: jobRec.graphic_instructions,
+        describe: jobRec.describe,
+        tags: jobRec.tags
+      });
+      results.push(result);
+    }
+    const markdown = scrutinizeViaDiff2(results.map(r => r.markdown))
+    return {
+      // The main text from the fallback LLM:
+      markdown: markdown || '(No fallback output)',
+      isFirstPage: !!results[0].isFirstPage,
+      // If describe=true was given, we might get a short description
+      description: results[0].description || '',
+      // If tags were provided and matched, we might get them
+      tags: results[0].tags || []
+    };
+  } else {
+    throw Error(`unrecognized value for .scrutinize: ${jobRec.scrutinize}`)
+  }
 }
 
 /**


### PR DESCRIPTION
I propose that the following be sent separately:
- Ability to run on a subset of a document's pages
- Prompt-based scrutinization
- Test cases with and without LLM calls