### PR TITLE
Chat json schema

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -782,6 +782,28 @@ function hideThinkingIndicator() {
 }
 
 /**
+ * A best effort JSON formatter.
+ */
+function tryPrettyPrintJSON(json) {
+  // TODO: try to render json without a markdown filter
+  try {
+    return ({
+      "messages": json.messages.map(msg => {
+          const role = msg['role']
+          let content = msg['content']
+          content = JSON.stringify(JSON.parse(content), null, 2)
+          // play with fire: seems totally bogus but works
+          content = "```\n" + content + "\n```"
+          return {role, content}
+      })
+    })
+  } catch(ex) {
+    console.error(ex)
+    return json
+  }
+}
+
+/**
  * Send message (user typed + attachments)
  */
 async function sendMessage() {
@@ -902,7 +924,10 @@ async function sendMessage() {
       data = { error: `Failed to parse response: ${parseError.message}` };
     }
     if (response.ok) {
-      const suffix = TranscriptFragment.fromJSON(data);
+      // If we asked to force JSON schema, then it's reasonable to expect that we
+      // got JSON back.
+      const dataFormatted = finalSchema ? tryPrettyPrintJSON(data) : data
+      const suffix = TranscriptFragment.fromJSON(dataFormatted);
       currentTranscript = currentTranscript.plus(suffix);
 
       // Display new assistant messages

--- a/public/script.js
+++ b/public/script.js
@@ -794,10 +794,14 @@ async function sendMessage() {
   // Build content array for the user message
   // We want to store both text + attachments
   const finalContent = [];
+  let finalSchema = null;
   if (typedText) {
     finalContent.push(typedText);
   }
   for (const att of pendingAttachments) {
+    if (att.fileName.endsWith(".schema.json")) {
+      finalSchema = att.content
+    }
     if (att.type === 'image') {
       // Convert to an ImageAttachment
       const imgAttachment = new ImageAttachment(att.content);
@@ -833,6 +837,17 @@ async function sendMessage() {
       temperature,
       transcript: currentTranscript.toJSON()
     };
+    if(finalSchema) {
+      const jsonSchemaParsed = JSON.parse(finalSchema)
+      payload.options = payload.opttions || {}
+      payload.options.response_format = {
+        'type': 'json_schema',
+        'json_schema': {
+          'name': 'forced-schema',
+          'schema': jsonSchemaParsed
+        }
+      }
+    }
 
     const response = await fetch(`${CHARMONATOR_API_URL}/transcript/extension`, {
       method: 'POST',


### PR DESCRIPTION
<img width="1574" height="1105" alt="chat_json_schema_2025-12-11 19-36-25" src="https://github.com/user-attachments/assets/872a24eb-5cb1-4115-afad-8bb606fc0a4f" />

On index.html:
- Detects attachment of a .schema.json extension, directing it to "Structured Output".
- When extending the transcript of a "Structured Output" request, applies pretty printing.  Currently that means pretty printing text and then lying to marked that it is a code block.