### PR TITLE
Feature/tool refactor

### DIFF
--- a/conf/example-config-with-mcp.json
+++ b/conf/example-config-with-mcp.json
@@ -1,0 +1,72 @@
+{
+  "$comment": "Example configuration with MCP server tools",
+
+  "toolboxes": {
+    "builtins": {
+      "code": "./tools/builtins.mjs"
+    }
+  },
+
+  "tools": {
+    "server": {
+      "calculator": {
+        "from": "builtins",
+        "export": "CalculatorTool",
+        "options": {}
+      }
+    },
+    "client": {
+      "open_file": {
+        "from": "client_tools",
+        "export": "OpenFileTool"
+      }
+    }
+  },
+
+  "mcp": {
+    "servers": {
+      "test": {
+        "command": "node",
+        "args": ["./mcp-servers/test-server.mjs"],
+        "env": {}
+      }
+    },
+    "tools": {
+      "echo": {
+        "server": "test",
+        "tool": "echo"
+      },
+      "calc": {
+        "server": "test",
+        "tool": "calculator"
+      }
+    }
+  },
+
+  "models": {
+    "gpt-4o": {
+      "api": "OpenAI",
+      "model_type": "chat",
+      "model": "gpt-4o",
+      "tools": {
+        "server": ["calculator"],
+        "client": ["open_file"],
+        "mcp": ["echo", "calc"]
+      }
+    },
+    "claude-default": {
+      "api": "Anthropic",
+      "model_type": "chat",
+      "model": "claude-sonnet-4-20250514",
+      "tools": {
+        "server": [],
+        "client": [],
+        "mcp": ["echo", "calc"]
+      }
+    }
+  },
+
+  "server": {
+    "port": 7779
+  }
+}

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -614,9 +614,321 @@ POST api/charmonator/v1/documents/chunks/annotations
 
 ---
 
+### 8. Markdown Operations (Synchronous)
+
+These endpoints provide synchronous, deterministic markdown processing. All operations complete immediately without job polling.
+
+#### 8a. List Markdown Chunking Strategies
+
+```
+GET api/charmonator/v1/markdown/strategies
+```
+
+- **Description**: Lists supported chunking strategies and their option schemas.
+
+- **Response**:
+  ```jsonc
+  {
+    "strategies": [
+      {
+        "id": "markdown_headers",
+        "description": "Header-aware splitting (LangChain-style MarkdownHeaderTextSplitter + token packing).",
+        "options_schema": {
+          "max_header_level": { "type": "integer", "min": 1, "max": 6, "default": 6 },
+          "include_headers_in_chunk": { "type": "boolean", "default": true }
+        }
+      },
+      {
+        "id": "markdown_blocks",
+        "description": "Block-aware splitting (paragraphs, lists, code blocks, tables) + token packing.",
+        "options_schema": { ... }
+      },
+      {
+        "id": "recursive_separators",
+        "description": "Recursive separator splitter (LangChain RecursiveCharacterTextSplitter behavior, but token-bounded).",
+        "options_schema": { ... }
+      },
+      {
+        "id": "sliding_window",
+        "description": "Pure token sliding windows (LangChain TokenTextSplitter behavior).",
+        "options_schema": {}
+      },
+      {
+        "id": "sentence_pack",
+        "description": "Sentence split + token packing (LangChain-like sentence splitter).",
+        "options_schema": { ... }
+      },
+      {
+        "id": "obsidian",
+        "description": "Obsidian-aware Markdown splitting (wikilinks, tags, callouts) + token packing.",
+        "options_schema": { ... }
+      }
+    ],
+    "supported_tokenizers": ["cl100k_base", "o200k_base"]
+  }
+  ```
+
+- **Errors**:
+  - 500 on unexpected server errors.
+
+---
+
+#### 8b. Normalize Markdown
+
+```
+POST api/charmonator/v1/markdown/normalize
+```
+
+- **Description**: Normalizes markdown in a deterministic way for stable hashing and chunking. No LLM work, purely syntactic cleanup.
+
+- **Request Body**:
+  ```jsonc
+  {
+    "markdown": "# Title\r\n\r\nSome text  \r\n\r\n- item\r\n",
+    "options": {
+      "line_endings": "lf",                  // "lf" | "crlf"
+      "trim_trailing_whitespace": true,
+      "collapse_multiple_blank_lines": true,
+      "ensure_trailing_newline": true,
+      "frontmatter": "preserve",             // "preserve" | "drop"
+      "obsidian": {
+        "normalize_callouts": true
+      }
+    }
+  }
+  ```
+
+- **Response**:
+  ```jsonc
+  {
+    "markdown": "# Title\n\nSome text\n\n- item\n",
+    "id": "sha256-of-normalized-markdown"
+  }
+  ```
+  - **`id`**: SHA-256 hash of the normalized content.
+
+- **Errors**:
+  - 400 if `markdown` is missing or not a string.
+  - 500 on unexpected errors.
+
+---
+
+#### 8c. Extract Plain Text and Metadata from Markdown
+
+```
+POST api/charmonator/v1/markdown/extract
+```
+
+- **Description**: Extracts embedding-friendly / search-friendly text and structured metadata (frontmatter, tags, wikilinks, headings).
+
+- **Request Body**:
+  ```jsonc
+  {
+    "markdown": "---\ntags: [foo]\n---\n# Title\n\nSee [[Note|alias]] and #bar.\n",
+    "options": {
+      "frontmatter": "metadata",            // "drop" | "metadata" | "prepend_text"
+      "strip_html": true,
+      "preserve_code_blocks": true,
+      "obsidian": {
+        "wikilinks": "text_only",           // "preserve" | "text_only" | "text_and_target"
+        "tags": "metadata_only"             // "preserve" | "metadata_only"
+      }
+    }
+  }
+  ```
+
+- **Response**:
+  ```jsonc
+  {
+    "text": "Title\n\nSee alias and bar.\n",
+    "metadata": {
+      "frontmatter": { "tags": ["foo"] },
+      "tags": ["bar", "foo"],
+      "links": [
+        { "raw": "[[Note|alias]]", "target": "Note", "text": "alias" }
+      ],
+      "headings": [
+        { "depth": 1, "text": "Title" }
+      ]
+    }
+  }
+  ```
+
+- **Errors**:
+  - 400 if `markdown` is missing.
+  - 500 on unexpected errors.
+
+---
+
+#### 8d. Segment Markdown into Atomic Units
+
+```
+POST api/charmonator/v1/markdown/segments
+```
+
+- **Description**: Splits markdown into deterministic segments that preserve structure. These are the atomic building blocks used by chunking strategies.
+
+- **Request Body**:
+  ```jsonc
+  {
+    "markdown": "# Title\n\nPara 1.\n\nPara 2.\n\n```js\nconsole.log('hi')\n```\n",
+    "strategy": "markdown_blocks",
+    "options": {
+      "atomic_blocks": ["code", "table", "list_item"]
+    }
+  }
+  ```
+
+- **Response**:
+  ```jsonc
+  {
+    "segments": [
+      {
+        "type": "heading",
+        "depth": 1,
+        "text": "# Title",
+        "span": { "start_line": 1, "end_line": 1 },
+        "header_path": ["Title"]
+      },
+      {
+        "type": "paragraph",
+        "text": "Para 1.",
+        "span": { "start_line": 3, "end_line": 3 },
+        "header_path": ["Title"]
+      },
+      {
+        "type": "code",
+        "language": "js",
+        "text": "```js\nconsole.log('hi')\n```",
+        "span": { "start_line": 7, "end_line": 9 },
+        "header_path": ["Title"]
+      }
+    ]
+  }
+  ```
+
+- **Errors**:
+  - 400 if `markdown` is missing.
+  - 400 if `strategy` is unknown.
+  - 500 on unexpected errors.
+
+---
+
+#### 8e. Chunk Markdown into Token-Bounded Chunks
+
+```
+POST api/charmonator/v1/markdown/chunks
+```
+
+- **Description**: Produces final chunks suitable for indexing and embedding, with deterministic chunk IDs, token counts, and optional overlap. Returns a [Document Object](#document-object-specification) with a new chunk group.
+
+- **Request Body** (Option A - raw markdown):
+  ```jsonc
+  {
+    "markdown": "# Title\n\nPara 1...\n\n## Sub\n\nPara 2...\n",
+    "strategy": "markdown_headers",
+    "max_tokens": 512,
+    "overlap_tokens": 64,
+    "tokenizer": "cl100k_base",        // OR "model": "openai:gpt-4o" (mutually exclusive)
+    "options": {
+      "max_header_level": 4,
+      "include_headers_in_chunk": true
+    },
+    "group_name": null                  // if null, server auto-generates
+  }
+  ```
+
+- **Request Body** (Option B - existing document):
+  ```jsonc
+  {
+    "document": {
+      "id": "mydoc",
+      "content": "# Title\n\nPara...\n"
+    },
+    "strategy": "obsidian",
+    "max_tokens": 512,
+    "overlap_tokens": 64,
+    "tokenizer": "cl100k_base",
+    "options": {
+      "frontmatter": "metadata",
+      "wikilinks": "text_and_target",
+      "tags": "metadata_only"
+    },
+    "group_name": "obsidian_chunks"
+  }
+  ```
+
+- **Parameters**:
+  - **`markdown`** or **`document`**: (required, mutually exclusive) Raw markdown string or existing document object.
+  - **`strategy`**: (required) One of: `markdown_headers`, `markdown_blocks`, `recursive_separators`, `sliding_window`, `sentence_pack`, `obsidian`.
+  - **`max_tokens`**: (required) Maximum tokens per chunk.
+  - **`overlap_tokens`**: (optional) Overlap tokens between chunks. Default: 0.
+  - **`tokenizer`** or **`model`**: (optional, mutually exclusive) Tokenizer encoding or model name to look up tokenizer. Default: `cl100k_base`.
+  - **`options`**: (optional) Strategy-specific options.
+  - **`group_name`**: (optional) Custom chunk group name. Auto-generated if null.
+
+- **Response**:
+  ```jsonc
+  {
+    "document": {
+      "id": "sha256hash...",
+      "content": "# Title\n\nPara 1...\n\n## Sub\n\nPara 2...\n",
+      "metadata": {
+        "mimetype": "text/markdown",
+        "chunking": {
+          "strategy": "markdown_headers",
+          "max_tokens": 512,
+          "overlap_tokens": 64,
+          "encoding": "cl100k_base"
+        }
+      },
+      "chunks": {
+        "markdown:markdown_headers(512,cl100k_base,overlap=64)": [
+          {
+            "id": "sha256hash.../markdown:markdown_headers(512,cl100k_base,overlap=64)@0",
+            "parent": "sha256hash...",
+            "content": "# Title\n\nPara 1...\n",
+            "metadata": {
+              "chunk_index": 0,
+              "token_count": 211,
+              "header_path": ["Title"],
+              "span": { "start_line": 1, "end_line": 3 }
+            }
+          },
+          {
+            "id": "sha256hash.../markdown:markdown_headers(512,cl100k_base,overlap=64)@1",
+            "parent": "sha256hash...",
+            "content": "## Sub\n\nPara 2...\n",
+            "metadata": {
+              "chunk_index": 1,
+              "token_count": 187,
+              "header_path": ["Title", "Sub"],
+              "span": { "start_line": 5, "end_line": 7 }
+            }
+          }
+        ]
+      }
+    },
+    "chunk_group": "markdown:markdown_headers(512,cl100k_base,overlap=64)",
+    "chunks_created": 2,
+    "warnings": []
+  }
+  ```
+
+- **Errors**:
+  - 400 if neither `markdown` nor `document` is provided.
+  - 400 if both `markdown` and `document` are provided.
+  - 400 if both `tokenizer` and `model` are provided.
+  - 400 if `max_tokens` is invalid (<= 0) or `overlap_tokens` >= `max_tokens`.
+  - 400 if `model` resolves to API tokenizer mode.
+  - 400 if `strategy` is unknown.
+  - 500 on unexpected errors.
+
+---
+
 ## Charmonizer Endpoints
 
-### 8. Convert Document (Long-Running with Page Tracking)
+### 9. Convert Document (Long-Running with Page Tracking)
 
 ```
 POST api/charmonizer/v1/conversions/documents
@@ -745,7 +1057,7 @@ DELETE api/charmonizer/v1/conversions/documents/{jobId}
 
 ---
 
-### 9. Summarize a Document (Long-Running)
+### 10. Summarize a Document (Long-Running)
 
 ```
 POST api/charmonizer/v1/summaries
@@ -911,7 +1223,7 @@ GET api/charmonizer/v1/summaries/{job_id}/result
 
 ---
 
-### 10. Compute Embeddings for a Document (Long-Running)
+### 11. Compute Embeddings for a Document (Long-Running)
 
 ```
 POST api/charmonizer/v1/embeddings
@@ -995,7 +1307,7 @@ DELETE api/charmonizer/v1/embeddings/{jobId}
 
 ---
 
-### 11. Document Chunkings (Long-Running)
+### 12. Document Chunkings (Long-Running)
 
 ```
 POST api/charmonizer/v1/chunkings

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -28,7 +28,7 @@ This document describes the **RESTful endpoints** exposed by **Charmonator** and
 ### 1. List Available Models
 
 ```
-GET /models
+GET api/charmonator/v1/models
 ```
 
 - **Description**: Lists all configured AI models for the server.
@@ -59,7 +59,7 @@ GET /models
 ### 2. Transcript Extension
 
 ```
-POST /transcript/extension
+POST api/charmonator/v1/transcript/extension
 ```
 
 - **Description**: Extends an existing conversation transcript using a specified model. This endpoint returns new messages in the conversation (usually from the assistant, possibly with tool calls/responses).  
@@ -130,7 +130,7 @@ POST /transcript/extension
 ### 3. Convert Image to Markdown
 
 ```
-POST /conversion/image
+POST api/charmonator/v1/conversion/image
 ```
 
 - **Description**:  
@@ -185,7 +185,7 @@ POST /conversion/image
 ### 4. Convert File to Markdown
 
 ```
-POST /conversion/file
+POST api/charmonator/v1/conversion/file
 ```
 
 - **Description**: Converts supported file types (e.g., `.docx`, `.pptx`, `.pdf`, `.txt`) to plain Markdown in a single shot. May not produce chunk-level detail (unlike the more complex Charmonizer routes).
@@ -211,7 +211,7 @@ POST /conversion/file
 ### 5. Generate Embedding
 
 ```
-POST /embedding
+POST api/charmonator/v1/embedding
 ```
 
 - **Description**: Creates an embedding vector for the given text.
@@ -244,7 +244,7 @@ POST /embedding
 #### 6a. Tokenize Text
 
 ```
-POST /tokens
+POST api/charmonator/v1/tokens
 ```
 
 - **Description**: Tokenizes text and returns the individual token strings.
@@ -288,7 +288,7 @@ POST /tokens
 #### 6b. Count Tokens
 
 ```
-POST /tokens/count
+POST api/charmonator/v1/tokens/count
 ```
 
 - **Description**: Counts tokens in text without returning individual tokens. Supports both local (tiktoken) and API-based counting.
@@ -352,7 +352,7 @@ These endpoints provide synchronous operations on JSON Document Objects (wrappin
 #### 7a. Wrap Content into Document
 
 ```
-POST /documents
+POST api/charmonator/v1/documents
 ```
 
 - **Description**: Wraps raw content into a valid document object with a generated ID.
@@ -385,7 +385,7 @@ POST /documents
 #### 7b. Combine Documents
 
 ```
-POST /documents/combine
+POST api/charmonator/v1/documents/combine
 ```
 
 - **Description**: Combines multiple documents into a single master document with a chunk group containing the source documents.
@@ -427,7 +427,7 @@ POST /documents/combine
 #### 7c. Extract Markdown from Document
 
 ```
-POST /documents/markdown
+POST api/charmonator/v1/documents/markdown
 ```
 
 - **Description**: Extracts markdown/text content from a document. If the document has a `content_chunk_group`, content is reassembled from chunks.
@@ -465,7 +465,7 @@ POST /documents/markdown
 #### 7d. Extract Summary from Document
 
 ```
-POST /documents/summary
+POST api/charmonator/v1/documents/summary
 ```
 
 - **Description**: Extracts a summary annotation from a document. Handles delta-fold format (arrays of `{"delta": "..."}` strings) by extracting and joining the delta values.
@@ -513,7 +513,7 @@ POST /documents/summary
 #### 7e. Merge Chunks by Token Count
 
 ```
-POST /documents/chunks/merge
+POST api/charmonator/v1/documents/chunks/merge
 ```
 
 - **Description**: Merges small chunks into larger ones up to a maximum token count. Creates a new chunk group with the merged results.
@@ -555,7 +555,7 @@ POST /documents/chunks/merge
 #### 7f. Extract Chunk Annotations
 
 ```
-POST /documents/chunks/annotations
+POST api/charmonator/v1/documents/chunks/annotations
 ```
 
 - **Description**: Extracts annotations from each chunk in a specified chunk group. Useful for retrieving per-chunk summaries or other annotations.
@@ -619,7 +619,7 @@ POST /documents/chunks/annotations
 ### 8. Convert Document (Long-Running with Page Tracking)
 
 ```
-POST /conversions/documents
+POST api/charmonizer/v1/conversions/documents
 ```
 
 - **Description**: Converts/transcribes an uploaded PDF into a [JSON Document Object](#document-object-specification) with chunk-based structure (e.g. pages). This is a **long-running** job that returns a `job_id` so you can poll until done.  
@@ -646,7 +646,7 @@ POST /conversions/documents
 #### Poll Job Status
 
 ```
-GET /conversions/documents/{jobId}
+GET api/charmonizer/v1/conversions/documents/{jobId}
 ```
 
 **Response** (example):
@@ -667,7 +667,7 @@ GET /conversions/documents/{jobId}
 #### Poll Final Result
 
 ```
-GET /conversions/documents/{jobId}/result
+GET api/charmonizer/v1/conversions/documents/{jobId}/result
 ```
 - If `pending`/`processing`, returns **202** + partial status.
 - If `error`, returns **500** + an error message.
@@ -735,7 +735,7 @@ GET /conversions/documents/{jobId}/result
 #### Cancel or Delete a Job
 
 ```
-DELETE /conversions/documents/{jobId}
+DELETE api/charmonizer/v1/conversions/documents/{jobId}
 ```
 - Removes the job (and any cached data) from the server.
 
@@ -748,7 +748,7 @@ DELETE /conversions/documents/{jobId}
 ### 9. Summarize a Document (Long-Running)
 
 ```
-POST /summaries
+POST api/charmonizer/v1/summaries
 ```
 
 - **Description**: Summarizes a [Document Object](#document-object-specification) in either a single pass or chunk-by-chunk. Returns a `job_id` to poll.
@@ -861,7 +861,7 @@ POST /summaries
 #### Polling Job Status
 
 ```
-GET /summaries/{job_id}
+GET api/charmonizer/v1/summaries/{job_id}
 ```
 
 **Response** (example):
@@ -879,7 +879,7 @@ GET /summaries/{job_id}
 #### Retrieving Final Result
 
 ```
-GET /summaries/{job_id}/result
+GET api/charmonizer/v1/summaries/{job_id}/result
 ```
 - If still `pending`/`processing`: HTTP 202 + partial status  
 - If `error`: HTTP 500 + error message  
@@ -914,7 +914,7 @@ GET /summaries/{job_id}/result
 ### 10. Compute Embeddings for a Document (Long-Running)
 
 ```
-POST /embeddings
+POST api/charmonizer/v1/embeddings
 ```
 
 - **Description**: Computes embeddings for all chunks in a specified group (usually `"pages"`). Returns a `job_id` to poll for completion.
@@ -942,7 +942,7 @@ POST /embeddings
 #### Poll Job Status
 
 ```
-GET /embeddings/{jobId}
+GET api/charmonizer/v1/embeddings/{jobId}
 ```
 **Response** (example):
 ```json
@@ -957,7 +957,7 @@ GET /embeddings/{jobId}
 #### Poll Final Result
 
 ```
-GET /embeddings/{jobId}/result
+GET api/charmonizer/v1/embeddings/{jobId}/result
 ```
 - If `pending`/`processing`, returns **202** + partial status.  
 - If `error`, returns **500** with an error.  
@@ -988,7 +988,7 @@ GET /embeddings/{jobId}/result
 #### Cancel or Delete a Job
 
 ```
-DELETE /embeddings/{jobId}
+DELETE api/charmonizer/v1/embeddings/{jobId}
 ```
 - Removes the job (and any data) from the server.  
 - Response: `{ "success": true }`
@@ -998,7 +998,7 @@ DELETE /embeddings/{jobId}
 ### 11. Document Chunkings (Long-Running)
 
 ```
-POST /chunkings
+POST api/charmonizer/v1/chunkings
 ```
 - **Description**: Splits or merges existing chunks in a [Document Object](#document-object-specification), returning a `job_id` to poll until the chunking operation is complete.  
 - **Currently** supports a single strategy: `"merge_and_split"`.  
@@ -1034,7 +1034,7 @@ POST /chunkings
 #### Poll Job Status
 
 ```
-GET /chunkings/:job_id
+GET api/charmonizer/v1/chunkings/{job_id}
 ```
 
 **Response** (example):
@@ -1053,7 +1053,7 @@ GET /chunkings/:job_id
 #### Poll Final Result
 
 ```
-GET /chunkings/:job_id/result
+GET api/charmonizer/v1/chunkings/{job_id}/result
 ```
 
 - If `status` is still `"pending"` or `"in_progress"`, returns **409** with `{"error":"Job not complete yet"}`.
@@ -1108,7 +1108,7 @@ The response typically:
 
 ## Transcript JSON Structure
 
-Endpoints like `/chat/extend_transcript` expect or return a **Transcript JSON** format.
+Endpoints like `api/charmonator/v1/transcript/extension` expect or return a **Transcript JSON** format.
 
 ### Overview
 

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -239,11 +239,117 @@ POST /embedding
 
 ---
 
-### 6. Document Operations
+### 6. Token Counting
+
+#### 6a. Tokenize Text
+
+```
+POST /tokens
+```
+
+- **Description**: Tokenizes text and returns the individual token strings.
+
+- **Request Body**:
+  ```jsonc
+  {
+    "text": "Hello, world!",           // Required: the text to tokenize
+    "tokenizer": "cl100k_base",         // Optional: explicit tokenizer encoding
+    "model": "openai:gpt-4o"            // Optional: look up tokenizer from model config
+  }
+  ```
+  - **`text`** (string, required): The text to tokenize.
+  - **`tokenizer`** (string, optional): Explicit tokenizer encoding name. Supported: `"cl100k_base"`, `"o200k_base"`.
+  - **`model`** (string, optional): Model name to look up tokenizer from config.
+
+  **Note**: `tokenizer` and `model` are mutually exclusive. If neither is provided, defaults to `cl100k_base`.
+
+- **Response**:
+  ```json
+  {
+    "tokens": ["Hello", ",", " world", "!"],
+    "count": 4,
+    "encoding": "cl100k_base",
+    "mode": "local"
+  }
+  ```
+  - **`tokens`**: Array of token strings.
+  - **`count`**: Number of tokens.
+  - **`encoding`**: The tokenizer encoding used.
+  - **`mode`**: Either `"local"` (tiktoken) or `"api"` (provider API).
+
+- **Errors**:
+  - 400 if `text` is missing or not a string.
+  - 400 if both `tokenizer` and `model` are provided.
+  - 400 if `tokenizer` is not a supported encoding.
+  - 500 on unexpected server errors.
+
+---
+
+#### 6b. Count Tokens
+
+```
+POST /tokens/count
+```
+
+- **Description**: Counts tokens in text without returning individual tokens. Supports both local (tiktoken) and API-based counting.
+
+- **Request Body**:
+  ```jsonc
+  {
+    "text": "Hello, world!",           // Required: the text to count tokens in
+    "tokenizer": "o200k_base",          // Optional: explicit tokenizer encoding
+    "model": "anthropic:claude-sonnet"  // Optional: look up tokenizer from model config
+  }
+  ```
+  - **`text`** (string, required): The text to count tokens in.
+  - **`tokenizer`** (string, optional): Explicit tokenizer encoding name.
+  - **`model`** (string, optional): Model name to look up tokenizer from config.
+
+- **Response** (local mode):
+  ```json
+  {
+    "count": 4,
+    "encoding": "cl100k_base",
+    "mode": "local"
+  }
+  ```
+
+- **Response** (API mode, when model has `tokenizer_mode: "api"`):
+  ```json
+  {
+    "count": 4,
+    "encoding": null,
+    "mode": "api"
+  }
+  ```
+
+- **Supported Tokenizers**:
+  | Encoding | Models |
+  |----------|--------|
+  | `cl100k_base` | GPT-4, GPT-3.5, text-embedding-3-*, Claude (approximation) |
+  | `o200k_base` | GPT-4o, GPT-5, o1, o3 |
+
+- **Provider Defaults**:
+  | Provider | Default Tokenizer |
+  |----------|-------------------|
+  | OpenAI, OpenAI_Azure | `o200k_base` |
+  | Anthropic, Anthropic_Bedrock | `cl100k_base` |
+  | Google | `cl100k_base` |
+  | ollama | `cl100k_base` |
+
+- **Errors**:
+  - 400 if `text` is missing or not a string.
+  - 400 if both `tokenizer` and `model` are provided.
+  - 400 if `tokenizer` is not a supported encoding.
+  - 500 on unexpected server errors.
+
+---
+
+### 7. Document Operations
 
 These endpoints provide synchronous operations on JSON Document Objects (wrapping, combining, extracting content, and chunk manipulation).
 
-#### 6a. Wrap Content into Document
+#### 7a. Wrap Content into Document
 
 ```
 POST /documents
@@ -276,7 +382,7 @@ POST /documents
 
 ---
 
-#### 6b. Combine Documents
+#### 7b. Combine Documents
 
 ```
 POST /documents/combine
@@ -318,7 +424,7 @@ POST /documents/combine
 
 ---
 
-#### 6c. Extract Markdown from Document
+#### 7c. Extract Markdown from Document
 
 ```
 POST /documents/markdown
@@ -356,7 +462,7 @@ POST /documents/markdown
 
 ---
 
-#### 6d. Extract Summary from Document
+#### 7d. Extract Summary from Document
 
 ```
 POST /documents/summary
@@ -404,7 +510,7 @@ POST /documents/summary
 
 ---
 
-#### 6e. Merge Chunks by Token Count
+#### 7e. Merge Chunks by Token Count
 
 ```
 POST /documents/chunks/merge
@@ -446,7 +552,7 @@ POST /documents/chunks/merge
 
 ---
 
-#### 6f. Extract Chunk Annotations
+#### 7f. Extract Chunk Annotations
 
 ```
 POST /documents/chunks/annotations
@@ -510,7 +616,7 @@ POST /documents/chunks/annotations
 
 ## Charmonizer Endpoints
 
-### 7. Convert Document (Long-Running with Page Tracking)
+### 8. Convert Document (Long-Running with Page Tracking)
 
 ```
 POST /conversions/documents
@@ -639,7 +745,7 @@ DELETE /conversions/documents/{jobId}
 
 ---
 
-### 8. Summarize a Document (Long-Running)
+### 9. Summarize a Document (Long-Running)
 
 ```
 POST /summaries
@@ -805,7 +911,7 @@ GET /summaries/{job_id}/result
 
 ---
 
-### 9. Compute Embeddings for a Document (Long-Running)
+### 10. Compute Embeddings for a Document (Long-Running)
 
 ```
 POST /embeddings
@@ -889,7 +995,7 @@ DELETE /embeddings/{jobId}
 
 ---
 
-### 10. Document Chunkings (Long-Running)
+### 11. Document Chunkings (Long-Running)
 
 ```
 POST /chunkings

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,28 @@ Aliases are resolved recursively, and circular references are detected and will 
       - (Optional) Fields used by various model providers to specify maximum context length or maximum tokens in the response.
       - For instance, "context_size" might be used for OpenAI or local LLM, "max_tokens" for Anthropic, etc.
 
+    - dimensions
+      - (Optional) For embedding models only. Specifies the output vector dimensionality.
+      - Used for storage planning (vector DB index sizing) and compatibility validation.
+      - OpenAI text-embedding-3 models support configurable dimensions via API.
+
+    - tokenizer
+      - (Optional) Explicit tokenizer encoding to use for this model when counting tokens via the `/tokens` endpoint.
+      - Supported values: `"cl100k_base"`, `"o200k_base"`
+      - If not specified, the tokenizer is inferred from the model name and provider.
+      - Default inference:
+        - OpenAI/Azure: `o200k_base` for GPT-4o, GPT-5, o1, o3; `cl100k_base` for GPT-4, GPT-3.5
+        - Anthropic: `cl100k_base` (approximation)
+        - Google: `cl100k_base` (approximation)
+        - ollama: `cl100k_base`
+
+    - tokenizer_mode
+      - (Optional) How to count tokens for this model: locally or via provider API.
+      - Valid values: `"local"`, `"api"`
+      - Default: `"local"`
+      - `"local"`: Uses tiktoken library for fast, offline token counting.
+      - `"api"`: Calls the provider's token counting API for accurate counts. Supported for Anthropic and Google models. Falls back to local if API is unavailable.
+
     - reasoning
       - (Optional) Object used for OpenAI reasoning models (o1, o3, etc.). For instance:
         ```json
@@ -520,7 +542,51 @@ Here:
 
 ---
 
-### 5) Example for **Google** (Gemini)
+### 5) Example for **Embedding Models**
+
+Embedding models convert text into vector representations for semantic search and similarity calculations.
+
+```jsonc
+{
+  "models": {
+    "openai:text-embedding-3-small": {
+      "api": "OpenAI",
+      "model_type": "embedding",
+      "model": "text-embedding-3-small",
+      "api_key": "OPENAI_API_KEY_HERE_OR_IN_SECRET_JSON",
+      "context_size": 8191,    // max input tokens
+      "dimensions": 1536       // output vector size
+    },
+
+    "openai:text-embedding-3-large": {
+      "api": "OpenAI",
+      "model_type": "embedding",
+      "model": "text-embedding-3-large",
+      "api_key": "OPENAI_API_KEY_HERE_OR_IN_SECRET_JSON",
+      "context_size": 8191,
+      "dimensions": 3072
+    },
+
+    "ollama:qwen3-embedding": {
+      "api": "ollama",
+      "model_type": "embedding",
+      "model": "qwen3-embedding",
+      "host": "http://localhost:11434",
+      "context_size": 8192,
+      "dimensions": 1024
+    }
+  }
+}
+```
+
+Here:
+- `model_type`: must be `"embedding"` for embedding models.
+- `context_size`: maximum input tokens the model accepts per request.
+- `dimensions`: output vector dimensionality (important for vector DB index sizing).
+
+---
+
+### 6) Example for **Google** (Gemini)
 
 ```jsonc
 {

--- a/lib/chat-model-server.mjs
+++ b/lib/chat-model-server.mjs
@@ -20,7 +20,6 @@ export class ChatModel {
 
     // Initialize empty maps for enabled tools
     this.enabledTools = new Map();
-    this.boundSession = null;
 
     // Check for named tools to enable in modelConfig:
     for (const toolName of modelConfig.tools || []) {
@@ -48,16 +47,6 @@ export class ChatModel {
     this.enabledTools.set(tool.name, tool);
   }
 
-  /**
-   * Bind this model to a specific chat session
-   * @param {ChatSession} session - The session to bind to
-   */
-  bindSession(session) {
-    this.boundSession = session;
-    // Get session-specific versions of all enabled tools
-    this.enabledTools = toolRegistry.getSessionTools(session);
-  }
-
   async runTools(msg) {
     const responses = [];
 
@@ -69,16 +58,7 @@ export class ChatModel {
           throw new Error(`Tool ${toolName} not found or not enabled`);
         }
 
-        let response;
-        if (tool.constructor.name === 'SessionTool') {
-          if (!this.boundSession) {
-            throw new Error('Session tool used without bound session');
-          }
-          response = await tool.run(args, this.boundSession);
-        } else {
-          response = await tool.run(args);
-        }
-
+        const response = await tool.run(args);
         responses.push(new ToolResponse(toolName, callId, String(response)));
       }
     }
@@ -119,41 +99,6 @@ export class ChatModel {
       temperature: this.temperature,
       model: this.modelConfig.model || this.modelConfig.deployment
     }, null, 2);
-  }
-}
-
-/**
- * Server-side ChatSession that maintains conversation state
- */
-export class ChatSession {
-  constructor(chatModel) {
-    this.chatModel = chatModel;
-    this.transcript = new TranscriptFragment();
-  }
-
-  get system() {
-    return this.chatModel.system;
-  }
-
-  set system(system) {
-    this.chatModel.setSystem(system);
-  }
-
-  async fetchRepliesTo(userMessage) {
-    const msg = typeof userMessage === 'string'
-      ? new Message('user', userMessage)
-      : userMessage;
-
-    this.transcript = this.transcript.plus(msg);
-    const suffix = await this.chatModel.extendTranscript(this.transcript);
-    this.transcript = this.transcript.plus(suffix);
-    return suffix;
-  }
-
-  async fetchReplyTo(userMessage) {
-    const suffix = await this.fetchRepliesTo(userMessage);
-    const lastMessage = suffix.messages[suffix.messages.length - 1];
-    return lastMessage.content;
   }
 }
 

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -12,5 +12,7 @@ export { setConfig,
 export { fetchProvider, fetchChatModel, createDefaultChatProvider } from './core.mjs';
 export { ModelProvider } from './providers/provider_base.mjs';
 export { Message, TranscriptFragment } from './transcript.mjs';
-export { ChatModel, ChatSession } from './chat-model-server.mjs';
+export { ChatModel } from './chat-model-server.mjs';
+export { ToolKind, ToolDefinition } from './tool-definition.mjs';
+export { BaseTool, StatelessTool, toolRegistry } from './tools.mjs';
 // Export other modules as needed

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -15,4 +15,5 @@ export { Message, TranscriptFragment } from './transcript.mjs';
 export { ChatModel } from './chat-model-server.mjs';
 export { ToolKind, ToolDefinition } from './tool-definition.mjs';
 export { BaseTool, StatelessTool, toolRegistry } from './tools.mjs';
-// Export other modules as needed
+export { toolRuntime, ToolRuntime } from './tool-runtime.mjs';
+export { mcpManager, MCPManager } from './mcp/mcp-manager.mjs';

--- a/lib/markdown/chunk.mjs
+++ b/lib/markdown/chunk.mjs
@@ -1,0 +1,571 @@
+/**
+ * lib/markdown/chunk.mjs
+ *
+ * Token-bounded chunking of markdown segments.
+ * Produces final chunks suitable for indexing and embedding.
+ */
+
+import crypto from 'crypto';
+import { countTokensLocal, tokenizeLocal } from '../tokenizer.mjs';
+import { segmentMarkdown } from './segment.mjs';
+import { normalizeMarkdown } from './normalize.mjs';
+
+/**
+ * @typedef {Object} Chunk
+ * @property {string} id - Chunk ID
+ * @property {string} parent - Parent document ID
+ * @property {string} content - Chunk text
+ * @property {Object} metadata - Chunk metadata
+ * @property {number} metadata.chunk_index
+ * @property {number} metadata.token_count
+ * @property {string[]} metadata.header_path
+ * @property {{ start_line: number, end_line: number }} metadata.span
+ */
+
+/**
+ * Generate a deterministic group name for chunks
+ * @param {string} strategy - Strategy name
+ * @param {number} maxTokens - Max tokens per chunk
+ * @param {string} encoding - Tokenizer encoding
+ * @param {number} overlapTokens - Overlap tokens
+ * @returns {string}
+ */
+export function generateGroupName(strategy, maxTokens, encoding, overlapTokens) {
+  return `markdown:${strategy}(${maxTokens},${encoding},overlap=${overlapTokens})`;
+}
+
+/**
+ * Generate a chunk ID
+ * @param {string} parentId - Parent document ID
+ * @param {string} groupName - Chunk group name
+ * @param {number} index - Chunk index
+ * @returns {string}
+ */
+export function generateChunkId(parentId, groupName, index) {
+  return `${parentId}/${groupName}@${index}`;
+}
+
+/**
+ * Pack segments into token-bounded chunks with overlap
+ * @param {Array} segments - Array of segments
+ * @param {Object} options - Chunking options
+ * @returns {Array} Array of chunks
+ */
+function packSegments(segments, options) {
+  const {
+    max_tokens,
+    overlap_tokens = 0,
+    encoding = 'cl100k_base',
+    parent_id,
+    group_name
+  } = options;
+
+  const chunks = [];
+  let currentChunk = {
+    texts: [],
+    tokens: 0,
+    headerPath: [],
+    startLine: null,
+    endLine: null
+  };
+
+  for (const segment of segments) {
+    const segmentTokens = countTokensLocal(segment.text, encoding);
+
+    // If this single segment exceeds max_tokens, we need to split it
+    if (segmentTokens > max_tokens) {
+      // Flush current chunk first
+      if (currentChunk.texts.length > 0) {
+        chunks.push(finalizeChunk(currentChunk, chunks.length, parent_id, group_name, encoding));
+        currentChunk = createNewChunk(currentChunk, overlap_tokens, encoding);
+      }
+
+      // Split the oversized segment
+      const splitChunks = splitOversizedSegment(segment, max_tokens, encoding);
+      for (const splitChunk of splitChunks) {
+        chunks.push({
+          id: generateChunkId(parent_id, group_name, chunks.length),
+          parent: parent_id,
+          content: splitChunk.text,
+          metadata: {
+            chunk_index: chunks.length,
+            token_count: splitChunk.tokens,
+            header_path: segment.header_path || [],
+            span: segment.span
+          }
+        });
+      }
+
+      continue;
+    }
+
+    // Check if adding this segment would exceed max_tokens
+    if (currentChunk.tokens + segmentTokens > max_tokens && currentChunk.texts.length > 0) {
+      // Finalize current chunk
+      chunks.push(finalizeChunk(currentChunk, chunks.length, parent_id, group_name, encoding));
+
+      // Start new chunk with overlap from previous
+      currentChunk = createNewChunk(currentChunk, overlap_tokens, encoding);
+    }
+
+    // Add segment to current chunk
+    currentChunk.texts.push(segment.text);
+    currentChunk.tokens += segmentTokens;
+    currentChunk.headerPath = segment.header_path || currentChunk.headerPath;
+
+    if (currentChunk.startLine === null) {
+      currentChunk.startLine = segment.span?.start_line || 1;
+    }
+    currentChunk.endLine = segment.span?.end_line || currentChunk.endLine;
+  }
+
+  // Finalize last chunk
+  if (currentChunk.texts.length > 0) {
+    chunks.push(finalizeChunk(currentChunk, chunks.length, parent_id, group_name, encoding));
+  }
+
+  return chunks;
+}
+
+/**
+ * Create a new chunk with overlap from the previous chunk
+ * @param {Object} previousChunk - Previous chunk
+ * @param {number} overlapTokens - Number of overlap tokens
+ * @param {string} encoding - Tokenizer encoding
+ * @returns {Object} New chunk state
+ */
+function createNewChunk(previousChunk, overlapTokens, encoding) {
+  if (overlapTokens <= 0 || previousChunk.texts.length === 0) {
+    return {
+      texts: [],
+      tokens: 0,
+      headerPath: previousChunk.headerPath,
+      startLine: null,
+      endLine: null
+    };
+  }
+
+  // Get overlap text from end of previous chunk
+  const fullText = previousChunk.texts.join('\n\n');
+  const tokens = tokenizeLocal(fullText, encoding);
+
+  if (tokens.length <= overlapTokens) {
+    // Entire previous chunk is overlap
+    return {
+      texts: [fullText],
+      tokens: tokens.length,
+      headerPath: previousChunk.headerPath,
+      startLine: previousChunk.startLine,
+      endLine: previousChunk.endLine
+    };
+  }
+
+  // For simplicity, approximate overlap by character ratio
+  // This provides a good approximation without requiring token decoding
+  const charRatio = overlapTokens / tokens.length;
+  const overlapText = fullText.slice(-Math.floor(fullText.length * charRatio));
+
+  return {
+    texts: [overlapText],
+    tokens: overlapTokens,
+    headerPath: previousChunk.headerPath,
+    startLine: previousChunk.startLine,
+    endLine: previousChunk.endLine
+  };
+}
+
+/**
+ * Finalize a chunk into the output format
+ * @param {Object} chunkState - Current chunk state
+ * @param {number} index - Chunk index
+ * @param {string} parentId - Parent document ID
+ * @param {string} groupName - Group name
+ * @param {string} encoding - Tokenizer encoding
+ * @returns {Chunk}
+ */
+function finalizeChunk(chunkState, index, parentId, groupName, encoding) {
+  const content = chunkState.texts.join('\n\n');
+  return {
+    id: generateChunkId(parentId, groupName, index),
+    parent: parentId,
+    content,
+    metadata: {
+      chunk_index: index,
+      token_count: countTokensLocal(content, encoding),
+      header_path: chunkState.headerPath,
+      span: {
+        start_line: chunkState.startLine || 1,
+        end_line: chunkState.endLine || 1
+      }
+    }
+  };
+}
+
+/**
+ * Split an oversized segment into multiple chunks
+ * @param {Object} segment - Segment to split
+ * @param {number} maxTokens - Max tokens per chunk
+ * @param {string} encoding - Tokenizer encoding
+ * @returns {Array<{ text: string, tokens: number }>}
+ */
+function splitOversizedSegment(segment, maxTokens, encoding) {
+  const text = segment.text;
+  const chunks = [];
+
+  // Try splitting by paragraphs first
+  const paragraphs = text.split(/\n\n+/);
+
+  if (paragraphs.length > 1) {
+    let current = { texts: [], tokens: 0 };
+
+    for (const para of paragraphs) {
+      const paraTokens = countTokensLocal(para, encoding);
+
+      if (paraTokens > maxTokens) {
+        // Flush current
+        if (current.texts.length > 0) {
+          chunks.push({
+            text: current.texts.join('\n\n'),
+            tokens: current.tokens
+          });
+          current = { texts: [], tokens: 0 };
+        }
+        // Split paragraph further
+        const subChunks = splitBySentences(para, maxTokens, encoding);
+        chunks.push(...subChunks);
+      } else if (current.tokens + paraTokens > maxTokens) {
+        // Flush and start new
+        if (current.texts.length > 0) {
+          chunks.push({
+            text: current.texts.join('\n\n'),
+            tokens: current.tokens
+          });
+        }
+        current = { texts: [para], tokens: paraTokens };
+      } else {
+        current.texts.push(para);
+        current.tokens += paraTokens;
+      }
+    }
+
+    if (current.texts.length > 0) {
+      chunks.push({
+        text: current.texts.join('\n\n'),
+        tokens: current.tokens
+      });
+    }
+
+    return chunks;
+  }
+
+  // Fall back to sentence splitting
+  return splitBySentences(text, maxTokens, encoding);
+}
+
+/**
+ * Split text by sentences
+ * @param {string} text - Text to split
+ * @param {number} maxTokens - Max tokens per chunk
+ * @param {string} encoding - Tokenizer encoding
+ * @returns {Array<{ text: string, tokens: number }>}
+ */
+function splitBySentences(text, maxTokens, encoding) {
+  // Simple sentence boundary detection
+  const sentences = text.match(/[^.!?]+[.!?]+/g) || [text];
+  const chunks = [];
+  let current = { texts: [], tokens: 0 };
+
+  for (const sentence of sentences) {
+    const sentTokens = countTokensLocal(sentence, encoding);
+
+    if (sentTokens > maxTokens) {
+      // Flush current
+      if (current.texts.length > 0) {
+        chunks.push({
+          text: current.texts.join(' '),
+          tokens: current.tokens
+        });
+        current = { texts: [], tokens: 0 };
+      }
+      // Split by words as last resort
+      const wordChunks = splitByWords(sentence, maxTokens, encoding);
+      chunks.push(...wordChunks);
+    } else if (current.tokens + sentTokens > maxTokens) {
+      if (current.texts.length > 0) {
+        chunks.push({
+          text: current.texts.join(' '),
+          tokens: current.tokens
+        });
+      }
+      current = { texts: [sentence], tokens: sentTokens };
+    } else {
+      current.texts.push(sentence);
+      current.tokens += sentTokens;
+    }
+  }
+
+  if (current.texts.length > 0) {
+    chunks.push({
+      text: current.texts.join(' '),
+      tokens: current.tokens
+    });
+  }
+
+  return chunks;
+}
+
+/**
+ * Split text by words (last resort)
+ * @param {string} text - Text to split
+ * @param {number} maxTokens - Max tokens per chunk
+ * @param {string} encoding - Tokenizer encoding
+ * @returns {Array<{ text: string, tokens: number }>}
+ */
+function splitByWords(text, maxTokens, encoding) {
+  const words = text.split(/\s+/);
+  const chunks = [];
+  let current = { words: [], tokens: 0 };
+
+  for (const word of words) {
+    const wordTokens = countTokensLocal(word, encoding);
+
+    if (current.tokens + wordTokens > maxTokens) {
+      if (current.words.length > 0) {
+        const chunkText = current.words.join(' ');
+        chunks.push({
+          text: chunkText,
+          tokens: countTokensLocal(chunkText, encoding)
+        });
+      }
+      current = { words: [word], tokens: wordTokens };
+    } else {
+      current.words.push(word);
+      current.tokens += wordTokens;
+    }
+  }
+
+  if (current.words.length > 0) {
+    const chunkText = current.words.join(' ');
+    chunks.push({
+      text: chunkText,
+      tokens: countTokensLocal(chunkText, encoding)
+    });
+  }
+
+  return chunks;
+}
+
+/**
+ * Sliding window chunking (TokenTextSplitter style)
+ * @param {string} markdown - Raw markdown
+ * @param {Object} options - Chunking options
+ * @returns {Array} Array of chunks
+ */
+function chunkSlidingWindow(markdown, options) {
+  const {
+    max_tokens,
+    overlap_tokens = 0,
+    encoding = 'cl100k_base',
+    parent_id,
+    group_name
+  } = options;
+
+  const tokens = tokenizeLocal(markdown, encoding);
+  const stride = max_tokens - overlap_tokens;
+  const chunks = [];
+
+  for (let i = 0; i < tokens.length; i += stride) {
+    const windowTokens = tokens.slice(i, i + max_tokens);
+
+    // Decode tokens back to text
+    // Approximate by character position
+    const startChar = Math.floor((i / tokens.length) * markdown.length);
+    const endChar = Math.floor(((i + windowTokens.length) / tokens.length) * markdown.length);
+    const text = markdown.slice(startChar, endChar);
+
+    chunks.push({
+      id: generateChunkId(parent_id, group_name, chunks.length),
+      parent: parent_id,
+      content: text,
+      metadata: {
+        chunk_index: chunks.length,
+        token_count: windowTokens.length,
+        header_path: [],
+        span: { start_line: 1, end_line: 1 } // Approximate
+      }
+    });
+
+    if (i + max_tokens >= tokens.length) break;
+  }
+
+  return chunks;
+}
+
+/**
+ * Recursive separator chunking (RecursiveCharacterTextSplitter style)
+ * @param {string} markdown - Raw markdown
+ * @param {Object} options - Chunking options
+ * @returns {Array} Array of chunks
+ */
+function chunkRecursiveSeparators(markdown, options) {
+  const {
+    max_tokens,
+    overlap_tokens = 0,
+    encoding = 'cl100k_base',
+    parent_id,
+    group_name,
+    separators = ['\n\n', '\n', ' ', '']
+  } = options;
+
+  const segments = recursiveSplit(markdown, separators, max_tokens, encoding);
+  return packSegments(
+    segments.map((text, i) => ({
+      text,
+      header_path: [],
+      span: { start_line: 1, end_line: 1 }
+    })),
+    { max_tokens, overlap_tokens, encoding, parent_id, group_name }
+  );
+}
+
+/**
+ * Recursively split text using separators
+ * @param {string} text - Text to split
+ * @param {string[]} separators - Ordered list of separators
+ * @param {number} maxTokens - Max tokens per segment
+ * @param {string} encoding - Tokenizer encoding
+ * @returns {string[]} Array of text segments
+ */
+function recursiveSplit(text, separators, maxTokens, encoding) {
+  if (countTokensLocal(text, encoding) <= maxTokens) {
+    return [text];
+  }
+
+  if (separators.length === 0) {
+    // Last resort: split by character count
+    const segments = [];
+    const approxChars = maxTokens * 4;
+    for (let i = 0; i < text.length; i += approxChars) {
+      segments.push(text.slice(i, i + approxChars));
+    }
+    return segments;
+  }
+
+  const [sep, ...remainingSeps] = separators;
+
+  if (sep === '') {
+    return recursiveSplit(text, remainingSeps, maxTokens, encoding);
+  }
+
+  const parts = text.split(sep);
+  const segments = [];
+
+  for (const part of parts) {
+    if (countTokensLocal(part, encoding) <= maxTokens) {
+      segments.push(part);
+    } else {
+      segments.push(...recursiveSplit(part, remainingSeps, maxTokens, encoding));
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Chunk markdown into token-bounded chunks.
+ *
+ * @param {string} markdown - Raw markdown text
+ * @param {Object} options - Chunking options
+ * @param {string} options.strategy - Chunking strategy
+ * @param {number} options.max_tokens - Maximum tokens per chunk
+ * @param {number} [options.overlap_tokens=0] - Overlap tokens between chunks
+ * @param {string} [options.encoding='cl100k_base'] - Tokenizer encoding
+ * @param {string} [options.group_name] - Optional custom group name
+ * @param {Object} [options.strategy_options] - Strategy-specific options
+ * @returns {{ document: Object, chunk_group: string, chunks_created: number, warnings: string[] }}
+ */
+export function chunkMarkdown(markdown, options) {
+  const {
+    strategy = 'markdown_blocks',
+    max_tokens,
+    overlap_tokens = 0,
+    encoding = 'cl100k_base',
+    group_name,
+    strategy_options = {}
+  } = options;
+
+  // Normalize markdown first
+  const { markdown: normalizedMarkdown, id: parentId } = normalizeMarkdown(markdown);
+
+  // Generate group name if not provided
+  const finalGroupName = group_name || generateGroupName(strategy, max_tokens, encoding, overlap_tokens);
+
+  const warnings = [];
+  let chunks;
+
+  switch (strategy) {
+    case 'sliding_window':
+      chunks = chunkSlidingWindow(normalizedMarkdown, {
+        max_tokens,
+        overlap_tokens,
+        encoding,
+        parent_id: parentId,
+        group_name: finalGroupName
+      });
+      break;
+
+    case 'recursive_separators':
+      chunks = chunkRecursiveSeparators(normalizedMarkdown, {
+        max_tokens,
+        overlap_tokens,
+        encoding,
+        parent_id: parentId,
+        group_name: finalGroupName,
+        separators: strategy_options.separators
+      });
+      break;
+
+    case 'markdown_headers':
+    case 'markdown_blocks':
+    case 'sentence_pack':
+    case 'obsidian':
+    default:
+      // Use segmentation-based chunking
+      const segments = segmentMarkdown(normalizedMarkdown, strategy, strategy_options);
+      chunks = packSegments(segments, {
+        max_tokens,
+        overlap_tokens,
+        encoding,
+        parent_id: parentId,
+        group_name: finalGroupName
+      });
+      break;
+  }
+
+  // Build document object
+  const document = {
+    id: parentId,
+    content: normalizedMarkdown,
+    metadata: {
+      mimetype: 'text/markdown',
+      chunking: {
+        strategy,
+        max_tokens,
+        overlap_tokens,
+        encoding
+      }
+    },
+    chunks: {
+      [finalGroupName]: chunks
+    }
+  };
+
+  return {
+    document,
+    chunk_group: finalGroupName,
+    chunks_created: chunks.length,
+    warnings
+  };
+}
+
+export default chunkMarkdown;

--- a/lib/markdown/extract.mjs
+++ b/lib/markdown/extract.mjs
@@ -1,0 +1,316 @@
+/**
+ * lib/markdown/extract.mjs
+ *
+ * Extract plain text and metadata from markdown.
+ * Produces embedding-friendly / search-friendly text and structured metadata.
+ */
+
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkFrontmatter from 'remark-frontmatter';
+import { visit } from 'unist-util-visit';
+import yaml from 'yaml';
+
+/**
+ * Default extraction options
+ */
+const DEFAULT_OPTIONS = {
+  frontmatter: 'metadata',      // 'drop' | 'metadata' | 'prepend_text'
+  strip_html: true,
+  preserve_code_blocks: true,
+  obsidian: {
+    wikilinks: 'text_only',     // 'preserve' | 'text_only' | 'text_and_target'
+    tags: 'metadata_only'       // 'preserve' | 'metadata_only'
+  }
+};
+
+/**
+ * Extract frontmatter YAML from markdown
+ * @param {string} markdown - Raw markdown
+ * @returns {{ frontmatter: Object|null, body: string }}
+ */
+function parseFrontmatter(markdown) {
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (match) {
+    try {
+      const parsed = yaml.parse(match[1]);
+      return {
+        frontmatter: parsed || {},
+        body: markdown.slice(match[0].length)
+      };
+    } catch (e) {
+      // Invalid YAML, return as-is
+      return {
+        frontmatter: null,
+        body: markdown
+      };
+    }
+  }
+  return {
+    frontmatter: null,
+    body: markdown
+  };
+}
+
+/**
+ * Extract Obsidian wikilinks from text
+ * @param {string} text - Text containing wikilinks
+ * @returns {Array<{ raw: string, target: string, text: string }>}
+ */
+function extractWikilinks(text) {
+  const links = [];
+  const regex = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    links.push({
+      raw: match[0],
+      target: match[1].trim(),
+      text: (match[2] || match[1]).trim()
+    });
+  }
+  return links;
+}
+
+/**
+ * Extract Obsidian-style tags from text
+ * @param {string} text - Text containing tags
+ * @returns {string[]} Array of tag names (without #)
+ */
+function extractTags(text) {
+  const tags = new Set();
+  // Match #tag but not inside code blocks or URLs
+  const regex = /(?:^|[^&\w])#([\w/-]+)/g;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    tags.add(match[1]);
+  }
+  return Array.from(tags);
+}
+
+/**
+ * Extract headings from markdown AST
+ * @param {Object} tree - Markdown AST
+ * @returns {Array<{ depth: number, text: string }>}
+ */
+function extractHeadings(tree) {
+  const headings = [];
+  visit(tree, 'heading', (node) => {
+    const text = extractTextFromNode(node);
+    headings.push({
+      depth: node.depth,
+      text
+    });
+  });
+  return headings;
+}
+
+/**
+ * Extract plain text from an AST node
+ * @param {Object} node - AST node
+ * @returns {string} Plain text
+ */
+function extractTextFromNode(node) {
+  if (node.type === 'text') {
+    return node.value;
+  }
+  if (node.type === 'inlineCode') {
+    return node.value;
+  }
+  if (node.children) {
+    return node.children.map(extractTextFromNode).join('');
+  }
+  return '';
+}
+
+/**
+ * Convert AST to plain text with options
+ * @param {Object} tree - Markdown AST
+ * @param {Object} options - Extraction options
+ * @returns {string} Plain text
+ */
+function astToPlainText(tree, options) {
+  const parts = [];
+
+  visit(tree, (node) => {
+    switch (node.type) {
+      case 'text':
+        parts.push(node.value);
+        break;
+
+      case 'inlineCode':
+        parts.push(node.value);
+        break;
+
+      case 'code':
+        if (options.preserve_code_blocks) {
+          parts.push(node.value);
+        }
+        parts.push('\n\n');
+        break;
+
+      case 'heading':
+        // Text is extracted by traversing children
+        break;
+
+      case 'paragraph':
+        // Text is extracted by traversing children
+        break;
+
+      case 'listItem':
+        // Text is extracted by traversing children
+        break;
+
+      case 'html':
+        if (!options.strip_html) {
+          parts.push(node.value);
+        }
+        break;
+
+      case 'break':
+        parts.push('\n');
+        break;
+
+      case 'thematicBreak':
+        parts.push('\n\n');
+        break;
+    }
+  });
+
+  return parts.join('');
+}
+
+/**
+ * Process wikilinks in text according to options
+ * @param {string} text - Text with wikilinks
+ * @param {string} mode - 'preserve' | 'text_only' | 'text_and_target'
+ * @returns {string} Processed text
+ */
+function processWikilinks(text, mode) {
+  if (mode === 'preserve') {
+    return text;
+  }
+
+  return text.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (match, target, displayText) => {
+    const text = (displayText || target).trim();
+    const targetText = target.trim();
+
+    if (mode === 'text_only') {
+      return text;
+    }
+    if (mode === 'text_and_target') {
+      return text === targetText ? text : `${text} (${targetText})`;
+    }
+    return match;
+  });
+}
+
+/**
+ * Process tags in text according to options
+ * @param {string} text - Text with tags
+ * @param {string} mode - 'preserve' | 'metadata_only'
+ * @returns {string} Processed text
+ */
+function processTags(text, mode) {
+  if (mode === 'preserve') {
+    return text;
+  }
+  if (mode === 'metadata_only') {
+    // Remove tags from text (but keep the word if it's part of a larger context)
+    return text.replace(/(?:^|[^&\w])#([\w/-]+)/g, (match, tag) => {
+      // Keep leading space/char if present
+      return match.charAt(0) === '#' ? tag : match.charAt(0) + tag;
+    });
+  }
+  return text;
+}
+
+/**
+ * Extract plain text and metadata from markdown.
+ *
+ * @param {string} markdown - Raw markdown text
+ * @param {Object} options - Extraction options
+ * @param {string} [options.frontmatter='metadata'] - 'drop' | 'metadata' | 'prepend_text'
+ * @param {boolean} [options.strip_html=true] - Strip HTML tags
+ * @param {boolean} [options.preserve_code_blocks=true] - Keep code block content
+ * @param {Object} [options.obsidian] - Obsidian-specific options
+ * @param {string} [options.obsidian.wikilinks='text_only'] - 'preserve' | 'text_only' | 'text_and_target'
+ * @param {string} [options.obsidian.tags='metadata_only'] - 'preserve' | 'metadata_only'
+ * @returns {{ text: string, metadata: Object }}
+ */
+export function extractMarkdown(markdown, options = {}) {
+  const opts = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+    obsidian: {
+      ...DEFAULT_OPTIONS.obsidian,
+      ...options.obsidian
+    }
+  };
+
+  // Extract frontmatter
+  const { frontmatter, body } = parseFrontmatter(markdown);
+
+  // Extract wikilinks before parsing (they're not standard markdown)
+  const wikilinks = extractWikilinks(body);
+
+  // Extract tags before parsing
+  const allTags = extractTags(body);
+  const frontmatterTags = frontmatter?.tags || [];
+  const combinedTags = [...new Set([...allTags, ...(Array.isArray(frontmatterTags) ? frontmatterTags : [frontmatterTags])])];
+
+  // Parse markdown to AST
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkFrontmatter, ['yaml']);
+
+  const tree = processor.parse(body);
+
+  // Extract headings
+  const headings = extractHeadings(tree);
+
+  // Convert to plain text
+  let text = astToPlainText(tree, opts);
+
+  // Process Obsidian wikilinks
+  text = processWikilinks(text, opts.obsidian.wikilinks);
+
+  // Process Obsidian tags
+  text = processTags(text, opts.obsidian.tags);
+
+  // Handle frontmatter in text output
+  if (opts.frontmatter === 'prepend_text' && frontmatter) {
+    const frontmatterText = Object.entries(frontmatter)
+      .map(([k, v]) => `${k}: ${typeof v === 'object' ? JSON.stringify(v) : v}`)
+      .join('\n');
+    text = frontmatterText + '\n\n' + text;
+  }
+
+  // Clean up whitespace
+  text = text
+    .replace(/\n{3,}/g, '\n\n')  // Collapse multiple newlines
+    .trim() + '\n';
+
+  // Build metadata
+  const metadata = {
+    frontmatter: opts.frontmatter !== 'drop' ? frontmatter : undefined,
+    tags: combinedTags.length > 0 ? combinedTags : undefined,
+    links: wikilinks.length > 0 ? wikilinks : undefined,
+    headings: headings.length > 0 ? headings : undefined
+  };
+
+  // Remove undefined values
+  Object.keys(metadata).forEach(key => {
+    if (metadata[key] === undefined) {
+      delete metadata[key];
+    }
+  });
+
+  return {
+    text,
+    metadata
+  };
+}
+
+export default extractMarkdown;

--- a/lib/markdown/index.mjs
+++ b/lib/markdown/index.mjs
@@ -1,0 +1,51 @@
+/**
+ * lib/markdown/index.mjs
+ *
+ * Main exports for markdown processing module.
+ * Provides deterministic markdown normalization, extraction, segmentation, and chunking.
+ */
+
+// Core functions
+export { normalizeMarkdown } from './normalize.mjs';
+export { extractMarkdown } from './extract.mjs';
+export { segmentMarkdown, segmentByBlocks, segmentByHeaders } from './segment.mjs';
+export { chunkMarkdown, generateGroupName, generateChunkId } from './chunk.mjs';
+
+// Strategy registry
+export {
+  getStrategies,
+  getStrategy,
+  hasStrategy,
+  getSupportedTokenizers
+} from './strategies/index.mjs';
+
+// Re-export individual strategies for direct access
+export { markdownHeadersStrategy } from './strategies/markdown-headers.mjs';
+export { markdownBlocksStrategy } from './strategies/markdown-blocks.mjs';
+export { recursiveSeparatorsStrategy } from './strategies/recursive-separators.mjs';
+export { slidingWindowStrategy } from './strategies/sliding-window.mjs';
+export { sentencePackStrategy } from './strategies/sentence-pack.mjs';
+export { obsidianStrategy } from './strategies/obsidian.mjs';
+
+// Import for default export
+import { normalizeMarkdown as _normalizeMarkdown } from './normalize.mjs';
+import { extractMarkdown as _extractMarkdown } from './extract.mjs';
+import { segmentMarkdown as _segmentMarkdown } from './segment.mjs';
+import { chunkMarkdown as _chunkMarkdown } from './chunk.mjs';
+import {
+  getStrategies as _getStrategies,
+  getStrategy as _getStrategy,
+  hasStrategy as _hasStrategy,
+  getSupportedTokenizers as _getSupportedTokenizers
+} from './strategies/index.mjs';
+
+export default {
+  normalizeMarkdown: _normalizeMarkdown,
+  extractMarkdown: _extractMarkdown,
+  segmentMarkdown: _segmentMarkdown,
+  chunkMarkdown: _chunkMarkdown,
+  getStrategies: _getStrategies,
+  getStrategy: _getStrategy,
+  hasStrategy: _hasStrategy,
+  getSupportedTokenizers: _getSupportedTokenizers
+};

--- a/lib/markdown/normalize.mjs
+++ b/lib/markdown/normalize.mjs
@@ -1,0 +1,186 @@
+/**
+ * lib/markdown/normalize.mjs
+ *
+ * Deterministic markdown normalization for stable hashing and chunking.
+ * No LLM work - purely syntactic cleanup.
+ */
+
+import crypto from 'crypto';
+
+/**
+ * Default normalization options
+ */
+const DEFAULT_OPTIONS = {
+  line_endings: 'lf',
+  trim_trailing_whitespace: true,
+  collapse_multiple_blank_lines: true,
+  ensure_trailing_newline: true,
+  frontmatter: 'preserve',
+  obsidian: {
+    normalize_callouts: false
+  }
+};
+
+/**
+ * Normalize line endings to LF or CRLF
+ * @param {string} text - Input text
+ * @param {string} mode - 'lf' or 'crlf'
+ * @returns {string} Text with normalized line endings
+ */
+function normalizeLineEndings(text, mode = 'lf') {
+  // First normalize all line endings to LF
+  let normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  // Convert to CRLF if requested
+  if (mode === 'crlf') {
+    normalized = normalized.replace(/\n/g, '\r\n');
+  }
+
+  return normalized;
+}
+
+/**
+ * Trim trailing whitespace from each line
+ * @param {string} text - Input text
+ * @returns {string} Text with trailing whitespace removed
+ */
+function trimTrailingWhitespace(text) {
+  return text.split('\n').map(line => line.trimEnd()).join('\n');
+}
+
+/**
+ * Collapse multiple consecutive blank lines into a single blank line
+ * @param {string} text - Input text
+ * @returns {string} Text with collapsed blank lines
+ */
+function collapseBlankLines(text) {
+  return text.replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * Ensure text ends with exactly one newline
+ * @param {string} text - Input text
+ * @returns {string} Text with trailing newline
+ */
+function ensureTrailingNewline(text) {
+  return text.trimEnd() + '\n';
+}
+
+/**
+ * Extract frontmatter from markdown
+ * @param {string} text - Input markdown
+ * @returns {{ frontmatter: string|null, body: string }} Frontmatter and body separated
+ */
+function extractFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (match) {
+    return {
+      frontmatter: match[1],
+      body: text.slice(match[0].length)
+    };
+  }
+  return {
+    frontmatter: null,
+    body: text
+  };
+}
+
+/**
+ * Normalize Obsidian callouts to canonical format
+ * @param {string} text - Input text
+ * @returns {string} Text with normalized callouts
+ */
+function normalizeObsidianCallouts(text) {
+  // Normalize callout syntax: > [!TYPE] with optional title
+  // Canonicalize spacing and casing of type
+  return text.replace(
+    /^(>\s*)\[!(\w+)\](\s*.*)?$/gm,
+    (match, prefix, type, title) => {
+      const normalizedType = type.toUpperCase();
+      const normalizedTitle = title ? title.trim() : '';
+      return normalizedTitle
+        ? `${prefix}[!${normalizedType}] ${normalizedTitle}`
+        : `${prefix}[!${normalizedType}]`;
+    }
+  );
+}
+
+/**
+ * Normalize markdown in a deterministic way for stable hashing and chunking.
+ *
+ * @param {string} markdown - Raw markdown text
+ * @param {Object} options - Normalization options
+ * @param {string} [options.line_endings='lf'] - 'lf' or 'crlf'
+ * @param {boolean} [options.trim_trailing_whitespace=true] - Remove trailing whitespace
+ * @param {boolean} [options.collapse_multiple_blank_lines=true] - Collapse multiple blank lines
+ * @param {boolean} [options.ensure_trailing_newline=true] - Ensure trailing newline
+ * @param {string} [options.frontmatter='preserve'] - 'preserve' or 'drop'
+ * @param {Object} [options.obsidian] - Obsidian-specific options
+ * @param {boolean} [options.obsidian.normalize_callouts=false] - Normalize callout formatting
+ * @returns {{ markdown: string, id: string }} Normalized markdown and SHA-256 hash ID
+ */
+export function normalizeMarkdown(markdown, options = {}) {
+  const opts = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+    obsidian: {
+      ...DEFAULT_OPTIONS.obsidian,
+      ...options.obsidian
+    }
+  };
+
+  let result = markdown;
+
+  // Step 1: Normalize line endings first (for consistent processing)
+  result = normalizeLineEndings(result, 'lf');
+
+  // Step 2: Handle frontmatter
+  let frontmatter = null;
+  if (opts.frontmatter === 'drop') {
+    const { body } = extractFrontmatter(result);
+    result = body;
+  } else {
+    // Preserve frontmatter - extract and reattach after processing body
+    const extracted = extractFrontmatter(result);
+    frontmatter = extracted.frontmatter;
+    result = extracted.body;
+  }
+
+  // Step 3: Trim trailing whitespace
+  if (opts.trim_trailing_whitespace) {
+    result = trimTrailingWhitespace(result);
+  }
+
+  // Step 4: Collapse multiple blank lines
+  if (opts.collapse_multiple_blank_lines) {
+    result = collapseBlankLines(result);
+  }
+
+  // Step 5: Normalize Obsidian callouts if requested
+  if (opts.obsidian && opts.obsidian.normalize_callouts) {
+    result = normalizeObsidianCallouts(result);
+  }
+
+  // Step 6: Reattach frontmatter if preserved
+  if (frontmatter !== null) {
+    result = `---\n${frontmatter}\n---\n${result}`;
+  }
+
+  // Step 7: Ensure trailing newline
+  if (opts.ensure_trailing_newline) {
+    result = ensureTrailingNewline(result);
+  }
+
+  // Step 8: Final line ending normalization
+  result = normalizeLineEndings(result, opts.line_endings);
+
+  // Generate deterministic ID from normalized content
+  const id = crypto.createHash('sha256').update(result).digest('hex');
+
+  return {
+    markdown: result,
+    id
+  };
+}
+
+export default normalizeMarkdown;

--- a/lib/markdown/segment.mjs
+++ b/lib/markdown/segment.mjs
@@ -1,0 +1,369 @@
+/**
+ * lib/markdown/segment.mjs
+ *
+ * Segment markdown into atomic units that preserve structure.
+ * These segments are the building blocks for chunking strategies.
+ */
+
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkFrontmatter from 'remark-frontmatter';
+import { visit } from 'unist-util-visit';
+
+/**
+ * @typedef {Object} Segment
+ * @property {string} type - 'heading'|'paragraph'|'code'|'table'|'list_item'|'blockquote'|'thematic_break'|'frontmatter'
+ * @property {string} text - The segment text content
+ * @property {number} [depth] - For headings, 1-6
+ * @property {string} [language] - For code blocks
+ * @property {{ start_line: number, end_line: number }} span - Line numbers
+ * @property {string[]} header_path - Breadcrumb of parent headings
+ */
+
+/**
+ * Convert AST position to line numbers
+ * @param {Object} position - AST position object
+ * @returns {{ start_line: number, end_line: number }}
+ */
+function getLineSpan(position) {
+  if (!position) {
+    return { start_line: 1, end_line: 1 };
+  }
+  return {
+    start_line: position.start.line,
+    end_line: position.end.line
+  };
+}
+
+/**
+ * Serialize an AST node back to markdown-like text
+ * @param {Object} node - AST node
+ * @param {string} originalText - Original markdown text
+ * @returns {string}
+ */
+function nodeToText(node, originalText) {
+  if (node.position) {
+    const start = node.position.start.offset;
+    const end = node.position.end.offset;
+    return originalText.slice(start, end);
+  }
+
+  // Fallback: reconstruct from node content
+  switch (node.type) {
+    case 'text':
+      return node.value;
+    case 'inlineCode':
+      return `\`${node.value}\``;
+    case 'code':
+      return '```' + (node.lang || '') + '\n' + node.value + '\n```';
+    case 'heading':
+      return '#'.repeat(node.depth) + ' ' + childrenToText(node);
+    case 'paragraph':
+      return childrenToText(node);
+    case 'listItem':
+      return childrenToText(node);
+    case 'blockquote':
+      return childrenToText(node).split('\n').map(l => '> ' + l).join('\n');
+    default:
+      if (node.children) {
+        return childrenToText(node);
+      }
+      return node.value || '';
+  }
+}
+
+/**
+ * Get text content from node children
+ * @param {Object} node - AST node
+ * @returns {string}
+ */
+function childrenToText(node) {
+  if (!node.children) return '';
+  return node.children.map(child => {
+    if (child.type === 'text') return child.value;
+    if (child.type === 'inlineCode') return child.value;
+    if (child.children) return childrenToText(child);
+    return child.value || '';
+  }).join('');
+}
+
+/**
+ * Segment markdown using block-level awareness
+ * @param {string} markdown - Raw markdown text
+ * @param {Object} options - Segmentation options
+ * @returns {Segment[]}
+ */
+export function segmentByBlocks(markdown, options = {}) {
+  const segments = [];
+  const headerPath = [];
+
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkFrontmatter, ['yaml']);
+
+  const tree = processor.parse(markdown);
+
+  // Process frontmatter first if present
+  visit(tree, 'yaml', (node) => {
+    segments.push({
+      type: 'frontmatter',
+      text: node.value,
+      span: getLineSpan(node.position),
+      header_path: []
+    });
+  });
+
+  // Walk the tree for block elements
+  visit(tree, (node, index, parent) => {
+    // Only process top-level or direct children of root/document
+    if (parent && parent.type !== 'root') {
+      return;
+    }
+
+    switch (node.type) {
+      case 'heading':
+        // Update header path
+        while (headerPath.length > 0 && headerPath[headerPath.length - 1].depth >= node.depth) {
+          headerPath.pop();
+        }
+        const headingText = childrenToText(node);
+        headerPath.push({ depth: node.depth, text: headingText });
+
+        segments.push({
+          type: 'heading',
+          depth: node.depth,
+          text: nodeToText(node, markdown),
+          span: getLineSpan(node.position),
+          header_path: headerPath.map(h => h.text)
+        });
+        break;
+
+      case 'paragraph':
+        segments.push({
+          type: 'paragraph',
+          text: nodeToText(node, markdown),
+          span: getLineSpan(node.position),
+          header_path: headerPath.map(h => h.text)
+        });
+        break;
+
+      case 'code':
+        segments.push({
+          type: 'code',
+          language: node.lang || undefined,
+          text: nodeToText(node, markdown),
+          span: getLineSpan(node.position),
+          header_path: headerPath.map(h => h.text)
+        });
+        break;
+
+      case 'table':
+        segments.push({
+          type: 'table',
+          text: nodeToText(node, markdown),
+          span: getLineSpan(node.position),
+          header_path: headerPath.map(h => h.text)
+        });
+        break;
+
+      case 'list':
+        // For lists, we can either treat as one segment or split by items
+        if (options.atomic_blocks?.includes('list_item')) {
+          // Split into individual list items
+          const listMarker = node.ordered ? '1.' : '-';
+          node.children.forEach((item, i) => {
+            segments.push({
+              type: 'list_item',
+              text: nodeToText(item, markdown),
+              span: getLineSpan(item.position),
+              header_path: headerPath.map(h => h.text)
+            });
+          });
+        } else {
+          // Treat entire list as one segment
+          segments.push({
+            type: 'list',
+            text: nodeToText(node, markdown),
+            span: getLineSpan(node.position),
+            header_path: headerPath.map(h => h.text)
+          });
+        }
+        break;
+
+      case 'blockquote':
+        segments.push({
+          type: 'blockquote',
+          text: nodeToText(node, markdown),
+          span: getLineSpan(node.position),
+          header_path: headerPath.map(h => h.text)
+        });
+        break;
+
+      case 'thematicBreak':
+        segments.push({
+          type: 'thematic_break',
+          text: '---',
+          span: getLineSpan(node.position),
+          header_path: headerPath.map(h => h.text)
+        });
+        break;
+
+      case 'html':
+        segments.push({
+          type: 'html',
+          text: node.value,
+          span: getLineSpan(node.position),
+          header_path: headerPath.map(h => h.text)
+        });
+        break;
+    }
+  });
+
+  return segments;
+}
+
+/**
+ * Segment markdown by headers (creating sections)
+ * @param {string} markdown - Raw markdown text
+ * @param {Object} options - Segmentation options
+ * @returns {Segment[]}
+ */
+export function segmentByHeaders(markdown, options = {}) {
+  const maxHeaderLevel = options.max_header_level || 6;
+  const includeHeadersInChunk = options.include_headers_in_chunk !== false;
+
+  const segments = [];
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkFrontmatter, ['yaml']);
+
+  const tree = processor.parse(markdown);
+  const lines = markdown.split('\n');
+
+  // Build section structure
+  const sections = [];
+  let currentSection = {
+    header: null,
+    headerPath: [],
+    content: [],
+    startLine: 1,
+    endLine: lines.length
+  };
+
+  visit(tree, (node, index, parent) => {
+    if (parent && parent.type !== 'root') return;
+
+    if (node.type === 'heading' && node.depth <= maxHeaderLevel) {
+      // Save previous section
+      if (currentSection.content.length > 0 || currentSection.header) {
+        currentSection.endLine = node.position.start.line - 1;
+        sections.push({ ...currentSection });
+      }
+
+      // Update header path
+      const newPath = [...currentSection.headerPath];
+      while (newPath.length > 0 && newPath[newPath.length - 1].depth >= node.depth) {
+        newPath.pop();
+      }
+      const headingText = childrenToText(node);
+      newPath.push({ depth: node.depth, text: headingText });
+
+      // Start new section
+      currentSection = {
+        header: {
+          depth: node.depth,
+          text: nodeToText(node, markdown),
+          span: getLineSpan(node.position)
+        },
+        headerPath: newPath,
+        content: [],
+        startLine: node.position.start.line,
+        endLine: lines.length
+      };
+    } else if (node.type !== 'yaml') {
+      currentSection.content.push({
+        node,
+        text: nodeToText(node, markdown),
+        span: getLineSpan(node.position)
+      });
+    }
+  });
+
+  // Save last section
+  if (currentSection.content.length > 0 || currentSection.header) {
+    sections.push(currentSection);
+  }
+
+  // Convert sections to segments
+  for (const section of sections) {
+    const headerPath = section.headerPath.map(h => h.text);
+
+    if (section.header && includeHeadersInChunk) {
+      // Include header with content
+      const allContent = [section.header.text];
+      for (const item of section.content) {
+        allContent.push(item.text);
+      }
+
+      segments.push({
+        type: 'section',
+        depth: section.header?.depth,
+        text: allContent.join('\n\n'),
+        span: {
+          start_line: section.startLine,
+          end_line: section.endLine
+        },
+        header_path: headerPath
+      });
+    } else {
+      // Header and content as separate segments
+      if (section.header) {
+        segments.push({
+          type: 'heading',
+          depth: section.header.depth,
+          text: section.header.text,
+          span: section.header.span,
+          header_path: headerPath
+        });
+      }
+
+      for (const item of section.content) {
+        segments.push({
+          type: 'content',
+          text: item.text,
+          span: item.span,
+          header_path: headerPath
+        });
+      }
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Segment markdown into atomic units.
+ *
+ * @param {string} markdown - Raw markdown text
+ * @param {string} strategy - Strategy name ('markdown_blocks' | 'markdown_headers')
+ * @param {Object} options - Strategy-specific options
+ * @returns {Segment[]}
+ */
+export function segmentMarkdown(markdown, strategy, options = {}) {
+  switch (strategy) {
+    case 'markdown_blocks':
+      return segmentByBlocks(markdown, options);
+
+    case 'markdown_headers':
+      return segmentByHeaders(markdown, options);
+
+    default:
+      // Default to block-level segmentation
+      return segmentByBlocks(markdown, options);
+  }
+}
+
+export default segmentMarkdown;

--- a/lib/markdown/strategies/index.mjs
+++ b/lib/markdown/strategies/index.mjs
@@ -1,0 +1,82 @@
+/**
+ * lib/markdown/strategies/index.mjs
+ *
+ * Strategy registry for markdown chunking strategies.
+ */
+
+import { markdownHeadersStrategy } from './markdown-headers.mjs';
+import { markdownBlocksStrategy } from './markdown-blocks.mjs';
+import { recursiveSeparatorsStrategy } from './recursive-separators.mjs';
+import { slidingWindowStrategy } from './sliding-window.mjs';
+import { sentencePackStrategy } from './sentence-pack.mjs';
+import { obsidianStrategy } from './obsidian.mjs';
+
+/**
+ * @typedef {Object} StrategyDefinition
+ * @property {string} id - Strategy identifier
+ * @property {string} description - Human-readable description
+ * @property {Object} options_schema - JSON Schema for strategy options
+ */
+
+/**
+ * Registry of all available chunking strategies
+ */
+const STRATEGIES = {
+  markdown_headers: markdownHeadersStrategy,
+  markdown_blocks: markdownBlocksStrategy,
+  recursive_separators: recursiveSeparatorsStrategy,
+  sliding_window: slidingWindowStrategy,
+  sentence_pack: sentencePackStrategy,
+  obsidian: obsidianStrategy
+};
+
+/**
+ * Get all registered strategies with their schemas.
+ * @returns {StrategyDefinition[]}
+ */
+export function getStrategies() {
+  return Object.values(STRATEGIES).map(strategy => ({
+    id: strategy.id,
+    description: strategy.description,
+    options_schema: strategy.options_schema
+  }));
+}
+
+/**
+ * Get a specific strategy by ID.
+ * @param {string} id - Strategy ID
+ * @returns {Object} Strategy implementation
+ * @throws {Error} If strategy not found
+ */
+export function getStrategy(id) {
+  const strategy = STRATEGIES[id];
+  if (!strategy) {
+    const available = Object.keys(STRATEGIES).join(', ');
+    throw new Error(`Unknown strategy "${id}". Available strategies: ${available}`);
+  }
+  return strategy;
+}
+
+/**
+ * Check if a strategy exists.
+ * @param {string} id - Strategy ID
+ * @returns {boolean}
+ */
+export function hasStrategy(id) {
+  return id in STRATEGIES;
+}
+
+/**
+ * Get list of supported tokenizer encodings
+ * @returns {string[]}
+ */
+export function getSupportedTokenizers() {
+  return ['cl100k_base', 'o200k_base'];
+}
+
+export default {
+  getStrategies,
+  getStrategy,
+  hasStrategy,
+  getSupportedTokenizers
+};

--- a/lib/markdown/strategies/markdown-blocks.mjs
+++ b/lib/markdown/strategies/markdown-blocks.mjs
@@ -1,0 +1,70 @@
+/**
+ * lib/markdown/strategies/markdown-blocks.mjs
+ *
+ * Block-aware splitting strategy.
+ * Splits by block elements (paragraphs, lists, code blocks, tables) with token packing.
+ */
+
+export const markdownBlocksStrategy = {
+  id: 'markdown_blocks',
+  description: 'Block-aware splitting (paragraphs, lists, code blocks, tables) + token packing.',
+  options_schema: {
+    atomic_blocks: {
+      type: 'array',
+      items: { type: 'string' },
+      default: ['code', 'table', 'list_item'],
+      description: 'Block types to treat as atomic (will not be split unless oversized)'
+    },
+    split_oversized_blocks: {
+      type: 'boolean',
+      default: true,
+      description: 'Split blocks that exceed max_tokens'
+    }
+  },
+
+  /**
+   * Validate options for this strategy
+   * @param {Object} options - Strategy options
+   * @returns {{ valid: boolean, errors: string[] }}
+   */
+  validateOptions(options = {}) {
+    const errors = [];
+    const validBlockTypes = ['code', 'table', 'list_item', 'paragraph', 'blockquote', 'heading'];
+
+    if (options.atomic_blocks !== undefined) {
+      if (!Array.isArray(options.atomic_blocks)) {
+        errors.push('atomic_blocks must be an array');
+      } else {
+        for (const block of options.atomic_blocks) {
+          if (!validBlockTypes.includes(block)) {
+            errors.push(`Invalid block type "${block}". Valid types: ${validBlockTypes.join(', ')}`);
+          }
+        }
+      }
+    }
+
+    if (options.split_oversized_blocks !== undefined) {
+      if (typeof options.split_oversized_blocks !== 'boolean') {
+        errors.push('split_oversized_blocks must be a boolean');
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors
+    };
+  },
+
+  /**
+   * Get default options
+   * @returns {Object}
+   */
+  getDefaultOptions() {
+    return {
+      atomic_blocks: ['code', 'table', 'list_item'],
+      split_oversized_blocks: true
+    };
+  }
+};
+
+export default markdownBlocksStrategy;

--- a/lib/markdown/strategies/markdown-headers.mjs
+++ b/lib/markdown/strategies/markdown-headers.mjs
@@ -1,0 +1,65 @@
+/**
+ * lib/markdown/strategies/markdown-headers.mjs
+ *
+ * Header-aware splitting strategy (LangChain MarkdownHeaderTextSplitter style).
+ * Splits by headings and packs sections into token-bounded chunks.
+ */
+
+export const markdownHeadersStrategy = {
+  id: 'markdown_headers',
+  description: 'Header-aware splitting (LangChain-style MarkdownHeaderTextSplitter + token packing).',
+  options_schema: {
+    max_header_level: {
+      type: 'integer',
+      min: 1,
+      max: 6,
+      default: 6,
+      description: 'Maximum header level to split on (1-6)'
+    },
+    include_headers_in_chunk: {
+      type: 'boolean',
+      default: true,
+      description: 'Include header text in chunk content'
+    }
+  },
+
+  /**
+   * Validate options for this strategy
+   * @param {Object} options - Strategy options
+   * @returns {{ valid: boolean, errors: string[] }}
+   */
+  validateOptions(options = {}) {
+    const errors = [];
+
+    if (options.max_header_level !== undefined) {
+      const level = options.max_header_level;
+      if (!Number.isInteger(level) || level < 1 || level > 6) {
+        errors.push('max_header_level must be an integer between 1 and 6');
+      }
+    }
+
+    if (options.include_headers_in_chunk !== undefined) {
+      if (typeof options.include_headers_in_chunk !== 'boolean') {
+        errors.push('include_headers_in_chunk must be a boolean');
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors
+    };
+  },
+
+  /**
+   * Get default options
+   * @returns {Object}
+   */
+  getDefaultOptions() {
+    return {
+      max_header_level: 6,
+      include_headers_in_chunk: true
+    };
+  }
+};
+
+export default markdownHeadersStrategy;

--- a/lib/markdown/strategies/obsidian.mjs
+++ b/lib/markdown/strategies/obsidian.mjs
@@ -1,0 +1,80 @@
+/**
+ * lib/markdown/strategies/obsidian.mjs
+ *
+ * Obsidian-aware markdown splitting strategy.
+ * Handles wikilinks, tags, callouts, and frontmatter with token packing.
+ */
+
+export const obsidianStrategy = {
+  id: 'obsidian',
+  description: 'Obsidian-aware Markdown splitting (wikilinks, tags, callouts) + token packing.',
+  options_schema: {
+    frontmatter: {
+      type: 'string',
+      enum: ['drop', 'metadata', 'prepend_text'],
+      default: 'metadata',
+      description: 'How to handle YAML frontmatter'
+    },
+    wikilinks: {
+      type: 'string',
+      enum: ['preserve', 'text_only', 'text_and_target'],
+      default: 'text_only',
+      description: 'How to process [[wikilinks|with aliases]]'
+    },
+    tags: {
+      type: 'string',
+      enum: ['preserve', 'metadata_only'],
+      default: 'metadata_only',
+      description: 'How to process #tags'
+    }
+  },
+
+  /**
+   * Validate options for this strategy
+   * @param {Object} options - Strategy options
+   * @returns {{ valid: boolean, errors: string[] }}
+   */
+  validateOptions(options = {}) {
+    const errors = [];
+
+    if (options.frontmatter !== undefined) {
+      const valid = ['drop', 'metadata', 'prepend_text'];
+      if (!valid.includes(options.frontmatter)) {
+        errors.push(`frontmatter must be one of: ${valid.join(', ')}`);
+      }
+    }
+
+    if (options.wikilinks !== undefined) {
+      const valid = ['preserve', 'text_only', 'text_and_target'];
+      if (!valid.includes(options.wikilinks)) {
+        errors.push(`wikilinks must be one of: ${valid.join(', ')}`);
+      }
+    }
+
+    if (options.tags !== undefined) {
+      const valid = ['preserve', 'metadata_only'];
+      if (!valid.includes(options.tags)) {
+        errors.push(`tags must be one of: ${valid.join(', ')}`);
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors
+    };
+  },
+
+  /**
+   * Get default options
+   * @returns {Object}
+   */
+  getDefaultOptions() {
+    return {
+      frontmatter: 'metadata',
+      wikilinks: 'text_only',
+      tags: 'metadata_only'
+    };
+  }
+};
+
+export default obsidianStrategy;

--- a/lib/markdown/strategies/recursive-separators.mjs
+++ b/lib/markdown/strategies/recursive-separators.mjs
@@ -1,0 +1,72 @@
+/**
+ * lib/markdown/strategies/recursive-separators.mjs
+ *
+ * Recursive separator splitting strategy (LangChain RecursiveCharacterTextSplitter style).
+ * Recursively splits using a list of separators until chunks are under max_tokens.
+ */
+
+export const recursiveSeparatorsStrategy = {
+  id: 'recursive_separators',
+  description: 'Recursive separator splitter (LangChain RecursiveCharacterTextSplitter behavior, but token-bounded).',
+  options_schema: {
+    separators: {
+      type: 'array',
+      items: { type: 'string' },
+      default: ['\\n\\n', '\\n', ' ', ''],
+      description: 'Ordered list of separators to try (most preferred first)'
+    },
+    keep_separator: {
+      type: 'string',
+      enum: ['none', 'prefix', 'suffix'],
+      default: 'suffix',
+      description: 'Where to keep the separator in split chunks'
+    }
+  },
+
+  /**
+   * Validate options for this strategy
+   * @param {Object} options - Strategy options
+   * @returns {{ valid: boolean, errors: string[] }}
+   */
+  validateOptions(options = {}) {
+    const errors = [];
+
+    if (options.separators !== undefined) {
+      if (!Array.isArray(options.separators)) {
+        errors.push('separators must be an array');
+      } else {
+        for (const sep of options.separators) {
+          if (typeof sep !== 'string') {
+            errors.push('All separators must be strings');
+            break;
+          }
+        }
+      }
+    }
+
+    if (options.keep_separator !== undefined) {
+      const valid = ['none', 'prefix', 'suffix'];
+      if (!valid.includes(options.keep_separator)) {
+        errors.push(`keep_separator must be one of: ${valid.join(', ')}`);
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors
+    };
+  },
+
+  /**
+   * Get default options
+   * @returns {Object}
+   */
+  getDefaultOptions() {
+    return {
+      separators: ['\n\n', '\n', ' ', ''],
+      keep_separator: 'suffix'
+    };
+  }
+};
+
+export default recursiveSeparatorsStrategy;

--- a/lib/markdown/strategies/sentence-pack.mjs
+++ b/lib/markdown/strategies/sentence-pack.mjs
@@ -1,0 +1,52 @@
+/**
+ * lib/markdown/strategies/sentence-pack.mjs
+ *
+ * Sentence split + token packing strategy.
+ * Splits text into sentences and packs them into token-bounded chunks.
+ */
+
+export const sentencePackStrategy = {
+  id: 'sentence_pack',
+  description: 'Sentence split + token packing (LangChain-like sentence splitter).',
+  options_schema: {
+    locale: {
+      type: 'string',
+      default: 'en',
+      description: 'Locale for sentence boundary detection (e.g., "en", "ja")'
+    }
+  },
+
+  /**
+   * Validate options for this strategy
+   * @param {Object} options - Strategy options
+   * @returns {{ valid: boolean, errors: string[] }}
+   */
+  validateOptions(options = {}) {
+    const errors = [];
+
+    if (options.locale !== undefined) {
+      if (typeof options.locale !== 'string') {
+        errors.push('locale must be a string');
+      } else if (options.locale.length < 2) {
+        errors.push('locale must be at least 2 characters');
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors
+    };
+  },
+
+  /**
+   * Get default options
+   * @returns {Object}
+   */
+  getDefaultOptions() {
+    return {
+      locale: 'en'
+    };
+  }
+};
+
+export default sentencePackStrategy;

--- a/lib/markdown/strategies/sliding-window.mjs
+++ b/lib/markdown/strategies/sliding-window.mjs
@@ -1,0 +1,37 @@
+/**
+ * lib/markdown/strategies/sliding-window.mjs
+ *
+ * Pure token sliding window strategy (LangChain TokenTextSplitter style).
+ * Splits by token count with configurable overlap.
+ */
+
+export const slidingWindowStrategy = {
+  id: 'sliding_window',
+  description: 'Pure token sliding windows (LangChain TokenTextSplitter behavior).',
+  options_schema: {
+    // No additional options - just max_tokens and overlap_tokens from main config
+  },
+
+  /**
+   * Validate options for this strategy
+   * @param {Object} options - Strategy options
+   * @returns {{ valid: boolean, errors: string[] }}
+   */
+  validateOptions(options = {}) {
+    // No strategy-specific options to validate
+    return {
+      valid: true,
+      errors: []
+    };
+  },
+
+  /**
+   * Get default options
+   * @returns {Object}
+   */
+  getDefaultOptions() {
+    return {};
+  }
+};
+
+export default slidingWindowStrategy;

--- a/lib/mcp/mcp-manager.mjs
+++ b/lib/mcp/mcp-manager.mjs
@@ -1,0 +1,382 @@
+/**
+ * mcp-manager.mjs
+ *
+ * Manages MCP (Model Context Protocol) server lifecycle and tool proxying.
+ *
+ * Responsibilities:
+ * - Start MCP servers from config
+ * - Connect via stdio transport
+ * - Fetch tool schemas from servers
+ * - Proxy tool calls to appropriate server
+ * - Handle server shutdown
+ */
+
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
+import { ToolKind, ToolDefinition } from '../tool-definition.mjs';
+import { toolRegistry } from '../tools.mjs';
+
+/**
+ * Represents a connection to a single MCP server
+ */
+class MCPServerConnection extends EventEmitter {
+  constructor(serverId, config) {
+    super();
+    this.serverId = serverId;
+    this.config = config;
+    this.process = null;
+    this.tools = new Map();
+    this.pendingRequests = new Map();
+    this.requestId = 0;
+    this.buffer = '';
+    this.connected = false;
+  }
+
+  /**
+   * Start the MCP server process
+   */
+  async start() {
+    const { command, args = [], env = {} } = this.config;
+
+    return new Promise((resolve, reject) => {
+      try {
+        this.process = spawn(command, args, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: { ...process.env, ...env }
+        });
+
+        this.process.stdout.on('data', (data) => {
+          this._handleData(data.toString());
+        });
+
+        this.process.stderr.on('data', (data) => {
+          console.error(`[MCP:${this.serverId}] stderr: ${data.toString().trim()}`);
+        });
+
+        this.process.on('error', (err) => {
+          console.error(`[MCP:${this.serverId}] Process error:`, err.message);
+          this.connected = false;
+          this.emit('error', err);
+        });
+
+        this.process.on('exit', (code, signal) => {
+          console.log(`[MCP:${this.serverId}] Process exited (code=${code}, signal=${signal})`);
+          this.connected = false;
+          this.emit('exit', { code, signal });
+        });
+
+        // Initialize the connection
+        this._initialize()
+          .then(() => {
+            this.connected = true;
+            resolve();
+          })
+          .catch(reject);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Initialize the MCP connection
+   */
+  async _initialize() {
+    // Send initialize request
+    const initResult = await this._sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {
+        tools: {}
+      },
+      clientInfo: {
+        name: 'charmonator',
+        version: '1.0.0'
+      }
+    });
+
+    console.log(`[MCP:${this.serverId}] Initialized:`, initResult.serverInfo?.name || 'unknown');
+
+    // Send initialized notification
+    this._sendNotification('notifications/initialized', {});
+
+    // List available tools
+    await this._fetchTools();
+  }
+
+  /**
+   * Fetch tools from the MCP server
+   */
+  async _fetchTools() {
+    const result = await this._sendRequest('tools/list', {});
+    this.tools.clear();
+
+    for (const tool of result.tools || []) {
+      this.tools.set(tool.name, {
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema
+      });
+      console.log(`[MCP:${this.serverId}] Discovered tool: ${tool.name}`);
+    }
+
+    return this.tools;
+  }
+
+  /**
+   * Call a tool on this MCP server
+   */
+  async callTool(toolName, args) {
+    if (!this.connected) {
+      throw new Error(`MCP server ${this.serverId} is not connected`);
+    }
+
+    const result = await this._sendRequest('tools/call', {
+      name: toolName,
+      arguments: args
+    });
+
+    // Extract content from response
+    if (result.content && Array.isArray(result.content)) {
+      const textParts = result.content
+        .filter(c => c.type === 'text')
+        .map(c => c.text);
+      return textParts.join('\n') || JSON.stringify(result.content);
+    }
+
+    return JSON.stringify(result);
+  }
+
+  /**
+   * Send a JSON-RPC request
+   */
+  async _sendRequest(method, params) {
+    return new Promise((resolve, reject) => {
+      const id = ++this.requestId;
+      const request = {
+        jsonrpc: '2.0',
+        id,
+        method,
+        params
+      };
+
+      this.pendingRequests.set(id, { resolve, reject });
+
+      const message = JSON.stringify(request) + '\n';
+      this.process.stdin.write(message);
+
+      // Timeout after 30 seconds
+      setTimeout(() => {
+        if (this.pendingRequests.has(id)) {
+          this.pendingRequests.delete(id);
+          reject(new Error(`MCP request timeout: ${method}`));
+        }
+      }, 30000);
+    });
+  }
+
+  /**
+   * Send a JSON-RPC notification (no response expected)
+   */
+  _sendNotification(method, params) {
+    const notification = {
+      jsonrpc: '2.0',
+      method,
+      params
+    };
+    const message = JSON.stringify(notification) + '\n';
+    this.process.stdin.write(message);
+  }
+
+  /**
+   * Handle incoming data from the MCP server
+   */
+  _handleData(data) {
+    this.buffer += data;
+
+    // Process complete JSON messages (newline-delimited)
+    let newlineIndex;
+    while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
+      const line = this.buffer.slice(0, newlineIndex).trim();
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+
+      if (!line) continue;
+
+      try {
+        const message = JSON.parse(line);
+        this._handleMessage(message);
+      } catch (error) {
+        console.error(`[MCP:${this.serverId}] Failed to parse message:`, line);
+      }
+    }
+  }
+
+  /**
+   * Handle a parsed JSON-RPC message
+   */
+  _handleMessage(message) {
+    if (message.id !== undefined && this.pendingRequests.has(message.id)) {
+      const { resolve, reject } = this.pendingRequests.get(message.id);
+      this.pendingRequests.delete(message.id);
+
+      if (message.error) {
+        reject(new Error(message.error.message || 'MCP error'));
+      } else {
+        resolve(message.result);
+      }
+    } else if (message.method) {
+      // Handle notifications/requests from server
+      this.emit('notification', message);
+    }
+  }
+
+  /**
+   * Stop the MCP server
+   */
+  async stop() {
+    if (this.process) {
+      this.process.kill('SIGTERM');
+      this.process = null;
+      this.connected = false;
+    }
+  }
+}
+
+/**
+ * MCPManager - manages all MCP server connections
+ */
+export class MCPManager {
+  constructor() {
+    this.servers = new Map();
+    this.toolToServer = new Map();  // Maps tool name to server ID
+  }
+
+  /**
+   * Initialize MCP servers from config
+   * @param {Object} config - MCP configuration
+   */
+  async initialize(config) {
+    const mcpConfig = config.mcp || {};
+    const serverConfigs = mcpConfig.servers || {};
+    const toolMappings = mcpConfig.tools || {};
+
+    // Start all configured servers
+    for (const [serverId, serverConfig] of Object.entries(serverConfigs)) {
+      try {
+        console.log(`[MCPManager] Starting server: ${serverId}`);
+        const connection = new MCPServerConnection(serverId, serverConfig);
+        await connection.start();
+        this.servers.set(serverId, connection);
+
+        // Register discovered tools
+        for (const [toolName, toolInfo] of connection.tools) {
+          this._registerMCPTool(serverId, toolName, toolInfo);
+        }
+      } catch (error) {
+        console.error(`[MCPManager] Failed to start server ${serverId}:`, error.message);
+      }
+    }
+
+    // Register explicit tool mappings from config
+    for (const [toolAlias, mapping] of Object.entries(toolMappings)) {
+      const { server: serverId, tool: remoteName } = mapping;
+      const connection = this.servers.get(serverId);
+      if (connection) {
+        const toolInfo = connection.tools.get(remoteName);
+        if (toolInfo) {
+          this._registerMCPTool(serverId, remoteName, toolInfo, toolAlias);
+        }
+      }
+    }
+  }
+
+  /**
+   * Register an MCP tool in the global registry
+   */
+  _registerMCPTool(serverId, remoteName, toolInfo, alias = null) {
+    const toolName = alias || remoteName;
+
+    // Create a ToolDefinition for the MCP tool
+    const toolDef = new ToolDefinition({
+      kind: ToolKind.MCP,
+      name: toolName,
+      description: toolInfo.description || `MCP tool: ${remoteName}`,
+      input_schema: toolInfo.inputSchema || { type: 'object', properties: {} },
+      run: async (args) => {
+        return await this.callTool(toolName, args);
+      },
+      meta: {
+        serverId,
+        remoteName,
+        source: 'mcp'
+      }
+    });
+
+    toolRegistry.register(toolDef);
+    this.toolToServer.set(toolName, serverId);
+    console.log(`[MCPManager] Registered MCP tool: ${toolName} (server: ${serverId})`);
+  }
+
+  /**
+   * Call an MCP tool
+   * @param {string} toolName - Tool name
+   * @param {Object} args - Tool arguments
+   * @returns {Promise<any>} Tool result
+   */
+  async callTool(toolName, args) {
+    const serverId = this.toolToServer.get(toolName);
+    if (!serverId) {
+      throw new Error(`No MCP server found for tool: ${toolName}`);
+    }
+
+    const connection = this.servers.get(serverId);
+    if (!connection) {
+      throw new Error(`MCP server not connected: ${serverId}`);
+    }
+
+    // Get the remote tool name (might be different from alias)
+    const tool = toolRegistry.getTool(toolName);
+    const remoteName = tool?.meta?.remoteName || toolName;
+
+    return await connection.callTool(remoteName, args);
+  }
+
+  /**
+   * Check if this is an MCP tool
+   */
+  hasTool(toolName) {
+    return this.toolToServer.has(toolName);
+  }
+
+  /**
+   * Get all MCP tools
+   */
+  getAllTools() {
+    const tools = [];
+    for (const [toolName, serverId] of this.toolToServer) {
+      const tool = toolRegistry.getTool(toolName);
+      if (tool) {
+        tools.push({
+          name: toolName,
+          serverId,
+          description: tool.description
+        });
+      }
+    }
+    return tools;
+  }
+
+  /**
+   * Shutdown all MCP servers
+   */
+  async shutdown() {
+    for (const [serverId, connection] of this.servers) {
+      console.log(`[MCPManager] Stopping server: ${serverId}`);
+      await connection.stop();
+    }
+    this.servers.clear();
+    this.toolToServer.clear();
+  }
+}
+
+// Singleton instance
+export const mcpManager = new MCPManager();

--- a/lib/providers/provider_anthropic.mjs
+++ b/lib/providers/provider_anthropic.mjs
@@ -10,6 +10,7 @@ import {
   ImageAttachment,
   DocumentAttachment,
 } from '../transcript.mjs';
+import { ToolKind } from '../tool-definition.mjs';
 import Anthropic from '@anthropic-ai/sdk';
 import { AnthropicBedrock } from '@anthropic-ai/bedrock-sdk';
 
@@ -316,16 +317,38 @@ class AnthropicChatModel extends ChatModel {
         }
       }
 
-      // If any tool calls were made, handle them by running the tools
+      // If any tool calls were made, handle them with mixed-batch logic
       if (toolCalls.length > 0) {
-        const toolCallMessage = new Message('tool_call', toolCalls);
-        let newSuffix = suffix.plus(toolCallMessage);
+        // Separate tool calls into server/MCP tools and client tools
+        const serverCalls = [];
+        const clientCalls = [];
 
-        // Actually run those tools
-        const toolResponse = await this.runTools(toolCallMessage);
-        newSuffix = newSuffix.plus(toolResponse);
+        for (const tc of toolCalls) {
+          const tool = this.enabledTools.get(tc.toolName);
+          if (tool && tool.kind === ToolKind.CLIENT) {
+            clientCalls.push(tc);
+          } else {
+            serverCalls.push(tc);
+          }
+        }
 
-        // Re-invoke extendTranscript (recursively) with updated suffix
+        let newSuffix = suffix;
+
+        // Execute server/MCP tools first
+        if (serverCalls.length > 0) {
+          const serverToolCallMessage = new Message('tool_call', serverCalls);
+          newSuffix = newSuffix.plus(serverToolCallMessage);
+          const toolResponse = await this.runTools(serverToolCallMessage);
+          newSuffix = newSuffix.plus(toolResponse);
+        }
+
+        // If there are client tools, stop recursion and return with pending client calls
+        if (clientCalls.length > 0) {
+          const clientToolCallMessage = new Message('tool_call', clientCalls);
+          return newSuffix.plus(clientToolCallMessage);
+        }
+
+        // No client tools - recurse as normal with server tool results
         return this.extendTranscript(prefix, callOnOutput, newSuffix, streamOrOptions);
       }
 

--- a/lib/providers/provider_anthropic.mjs
+++ b/lib/providers/provider_anthropic.mjs
@@ -185,6 +185,28 @@ export class AnthropicProvider extends ModelProvider {
   createChatModel() {
     return new AnthropicChatModel(this, this.client, this.modelConfig);
   }
+
+  /**
+   * Count tokens using Anthropic's token counting API.
+   * Falls back to local tiktoken approximation if API call fails.
+   * @param {string} text - The text to count tokens in
+   * @returns {Promise<number>} The token count
+   * @see https://docs.anthropic.com/en/docs/build-with-claude/token-counting
+   */
+  async countTokens(text) {
+    try {
+      const response = await this.client.messages.countTokens({
+        model: this.modelConfig.model,
+        messages: [{ role: 'user', content: text }]
+      });
+      return response.input_tokens;
+    } catch (err) {
+      console.warn('[AnthropicProvider] Token counting API failed, using local approximation:', err.message);
+      // Fallback to local tiktoken with cl100k_base
+      const { countTokensLocal } = await import('../tokenizer.mjs');
+      return countTokensLocal(text, 'cl100k_base');
+    }
+  }
 }
 
 /**

--- a/lib/providers/provider_google.mjs
+++ b/lib/providers/provider_google.mjs
@@ -13,9 +13,34 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 export class GoogleProvider extends ModelProvider {
   constructor(modelConfig) {
     super(modelConfig);
+    // Initialize the client for token counting
+    this._gClient = new GoogleGenerativeAI(
+      modelConfig.api_key || process.env.GOOGLE_AI_API_KEY
+    );
+    this.modelName = modelConfig.model || 'gemini-2.0-flash';
   }
+
   createChatModel() {
     return new GoogleChatModel(this.modelConfig);
+  }
+
+  /**
+   * Count tokens using Google's countTokens API.
+   * Falls back to local tiktoken approximation if API call fails.
+   * @param {string} text - The text to count tokens in
+   * @returns {Promise<number>} The token count
+   */
+  async countTokens(text) {
+    try {
+      const model = this._gClient.getGenerativeModel({ model: this.modelName });
+      const result = await model.countTokens(text);
+      return result.totalTokens;
+    } catch (err) {
+      console.warn('[GoogleProvider] Token counting API failed, using local approximation:', err.message);
+      // Fallback to local tiktoken with cl100k_base
+      const { countTokensLocal } = await import('../tokenizer.mjs');
+      return countTokensLocal(text, 'cl100k_base');
+    }
   }
 }
 

--- a/lib/providers/provider_ollama.mjs
+++ b/lib/providers/provider_ollama.mjs
@@ -3,6 +3,7 @@
 import { ModelProvider } from './provider_base.mjs';
 import { ChatModel, Message, TranscriptFragment } from '../chat-model-server.mjs';
 import { ToolCall, ToolResponse, ImageAttachment } from '../transcript.mjs';
+import { ToolKind } from '../tool-definition.mjs';
 import { Ollama } from 'ollama';
 
 export class OllamaProvider extends ModelProvider {
@@ -237,31 +238,53 @@ class OllamaChatModel extends ChatModel {
       }
     }
 
-    // 5) If we found tool calls, run them
+    // 5) If we found tool calls, handle them with mixed-batch logic
     if (toolCalls.length > 0) {
-      // 5a) conditionally append the assistant text (only if it’s non-empty)
+      // 5a) conditionally append the assistant text (only if it's non-empty)
       if (finalAssistantText && finalAssistantText.trim() !== '') {
         suffix = suffix.plus(new Message('assistant', finalAssistantText));
       } else {
         console.log('[OllamaChatModel] Skipping empty assistant message that only held tool calls.');
       }
 
+      // Separate tool calls into server/MCP and client tools
+      const serverCalls = [];
+      const clientCalls = [];
+
       for (const tcall of toolCalls) {
         const { name, arguments: argObj } = tcall.function ?? {};
-        const callId = `call-${Date.now()}`;
-        console.log('[OllamaChatModel] Building ToolCall for name:', name, 'with args:', argObj);
-
+        const tool = this.enabledTools.get(name);
+        const callId = `call-${Date.now()}-${Math.random().toString(36).slice(2)}`;
         const newToolCall = new ToolCall(name, callId, 'function', argObj);
-        const toolCallMsg = new Message('tool_call', [newToolCall]);
+
+        if (tool && tool.kind === ToolKind.CLIENT) {
+          clientCalls.push(newToolCall);
+        } else {
+          serverCalls.push(newToolCall);
+        }
+      }
+
+      // Execute server/MCP tools first
+      for (const tc of serverCalls) {
+        console.log('[OllamaChatModel] Building ToolCall for name:', tc.toolName, 'with args:', tc.arguments);
+        const toolCallMsg = new Message('tool_call', [tc]);
         suffix = suffix.plus(toolCallMsg);
 
-        console.log('[OllamaChatModel] Running the tool now...');
+        console.log('[OllamaChatModel] Running the server tool now...');
         const toolResponseMsg = await this.runTools(toolCallMsg);
         suffix = suffix.plus(toolResponseMsg);
 
         console.log('[OllamaChatModel] Tool responded with:\n', toolResponseMsg);
       }
 
+      // If there are client tools, stop and return with pending client calls
+      if (clientCalls.length > 0) {
+        console.log('[OllamaChatModel] Client tools detected. Stopping recursion to let client handle.');
+        const clientToolCallMsg = new Message('tool_call', clientCalls);
+        return suffix.plus(clientToolCallMsg);
+      }
+
+      // No client tools - recurse as normal
       console.log(`[OllamaChatModel] Tools were called. Re-invoking _multiStepLoop with depth=${depth + 1}...`);
       return this._multiStepLoop(prefix, suffix, callOnOutput, stream, invocationOptions, depth + 1);
     }

--- a/lib/providers/provider_openai.mjs
+++ b/lib/providers/provider_openai.mjs
@@ -8,6 +8,7 @@ import {
   DocumentAttachment
 } from '../transcript.mjs';
 import { ChatModel } from '../chat-model-server.mjs';
+import { ToolKind } from '../tool-definition.mjs';
 import OpenAI from 'openai';
 import { AzureOpenAI } from 'openai';
 import { ProviderException } from './provider_exception.mjs';
@@ -289,8 +290,16 @@ class OpenAIChatModel extends ChatModel {
 
             const callId = `call-${Date.now()}`;
             const toolCall = new ToolCall(name, callId, 'function', JSON.parse(args));
-            const toolCallMessage = new Message('tool_call', [toolCall]);
 
+            // Check if this is a client tool
+            if (tool.kind === ToolKind.CLIENT) {
+              // Stop recursion - return with pending client tool call
+              const clientToolCallMessage = new Message('tool_call', [toolCall]);
+              return suffix.plus(clientToolCallMessage);
+            }
+
+            // Execute server/MCP tool
+            const toolCallMessage = new Message('tool_call', [toolCall]);
             let newSuffix = suffix.plus(toolCallMessage);
             const toolResponse = await this.runTools(toolCallMessage);
             newSuffix = newSuffix.plus(toolResponse);
@@ -339,8 +348,16 @@ class OpenAIChatModel extends ChatModel {
 
             const callId = `call-${Date.now()}`;
             const toolCall = new ToolCall(name, callId, 'function', JSON.parse(args));
-            const toolCallMessage = new Message('tool_call', [toolCall]);
 
+            // Check if this is a client tool
+            if (tool.kind === ToolKind.CLIENT) {
+              // Stop recursion - return with pending client tool call
+              const clientToolCallMessage = new Message('tool_call', [toolCall]);
+              return suffix.plus(clientToolCallMessage);
+            }
+
+            // Execute server/MCP tool
+            const toolCallMessage = new Message('tool_call', [toolCall]);
             let newSuffix = suffix.plus(toolCallMessage);
             const toolResponse = await this.runTools(toolCallMessage);
             newSuffix = newSuffix.plus(toolResponse);

--- a/lib/providers/provider_openai.mjs
+++ b/lib/providers/provider_openai.mjs
@@ -137,13 +137,16 @@ class OpenAIChatModel extends ChatModel {
     }
     messages.push(...prefixMessages, ...suffixMessages);
 
-    // Convert enabled tools to "functions" parameter
-    let functions = null;
+    // Convert enabled tools to "tools" parameter (modern format)
+    let tools = null;
     if (this.enabledTools && this.enabledTools.size > 0) {
-      functions = Array.from(this.enabledTools.values()).map(tool => ({
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.input_schema
+      tools = Array.from(this.enabledTools.values()).map(tool => ({
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.input_schema
+        }
       }));
     }
 
@@ -153,7 +156,7 @@ class OpenAIChatModel extends ChatModel {
       messages: messages,
       temperature: this.temperature,
       stream: stream,
-      functions: functions
+      tools: tools
     };
 
     // Handle max_output_tokens if provided in invocationOptions
@@ -264,16 +267,25 @@ class OpenAIChatModel extends ChatModel {
               if (callOnOutput) {
                 callOnOutput(delta.content);
               }
-            } else if (delta.function_call) {
+            } else if (delta.tool_calls) {
+              // Modern tool_calls format
               if (!assistantMessage) {
-                assistantMessage = { role: 'assistant', content: null, function_call: {} };
+                assistantMessage = { role: 'assistant', content: null, tool_calls: [] };
               }
-              if (delta.function_call.name) {
-                assistantMessage.function_call.name = delta.function_call.name;
-              }
-              if (delta.function_call.arguments) {
-                assistantMessage.function_call.arguments =
-                  (assistantMessage.function_call.arguments || '') + delta.function_call.arguments;
+              for (const toolCallDelta of delta.tool_calls) {
+                const index = toolCallDelta.index;
+                if (!assistantMessage.tool_calls[index]) {
+                  assistantMessage.tool_calls[index] = { id: '', type: 'function', function: { name: '', arguments: '' } };
+                }
+                if (toolCallDelta.id) {
+                  assistantMessage.tool_calls[index].id = toolCallDelta.id;
+                }
+                if (toolCallDelta.function?.name) {
+                  assistantMessage.tool_calls[index].function.name = toolCallDelta.function.name;
+                }
+                if (toolCallDelta.function?.arguments) {
+                  assistantMessage.tool_calls[index].function.arguments += toolCallDelta.function.arguments;
+                }
               }
             }
           }
@@ -282,13 +294,16 @@ class OpenAIChatModel extends ChatModel {
             messages.push(assistantMessage);
           }
 
-          // If there's a function call
-          if (assistantMessage?.function_call) {
-            const { name, arguments: args } = assistantMessage.function_call;
+          // If there are tool calls (modern format)
+          if (assistantMessage?.tool_calls && assistantMessage.tool_calls.length > 0) {
+            const toolCallObj = assistantMessage.tool_calls[0];
+            const name = toolCallObj.function.name;
+            const args = toolCallObj.function.arguments;
+            const callId = toolCallObj.id || `call-${Date.now()}`;
+
             const tool = this.enabledTools.get(name);
             if (!tool) throw new Error(`Function not found: ${name}`);
 
-            const callId = `call-${Date.now()}`;
             const toolCall = new ToolCall(name, callId, 'function', JSON.parse(args));
 
             // Check if this is a client tool
@@ -341,12 +356,16 @@ class OpenAIChatModel extends ChatModel {
 
           messages.push(message);
 
-          if (message.function_call) {
-            const { name, arguments: args } = message.function_call;
+          // Modern tool_calls format
+          if (message.tool_calls && message.tool_calls.length > 0) {
+            const toolCallObj = message.tool_calls[0];
+            const name = toolCallObj.function.name;
+            const args = toolCallObj.function.arguments;
+            const callId = toolCallObj.id || `call-${Date.now()}`;
+
             const tool = this.enabledTools.get(name);
             if (!tool) throw new Error(`Function not found: ${name}`);
 
-            const callId = `call-${Date.now()}`;
             const toolCall = new ToolCall(name, callId, 'function', JSON.parse(args));
 
             // Check if this is a client tool
@@ -700,28 +719,34 @@ function transcriptToOpenAI(transcript) {
  * Handles text, images (as `type: 'image_url'`), documents, tool calls, etc.
  */
 function messageToOpenAI(message) {
-  // 1) Tool calls -> becomes a function_call for the assistant role
+  // 1) Tool calls -> becomes tool_calls for the assistant role (modern format)
   if (message.role === 'tool_call') {
+    const toolCall = message.content[0];
     return {
       role: 'assistant',
-      function_call: {
-        name: message.content[0].toolName,
-        arguments: JSON.stringify(message.content[0].arguments)
-      },
-      content: null
+      content: null,
+      tool_calls: [{
+        id: toolCall.callId || `call-${Date.now()}`,
+        type: 'function',
+        function: {
+          name: toolCall.toolName,
+          arguments: JSON.stringify(toolCall.arguments)
+        }
+      }]
     };
   }
 
-  // 2) Tool responses -> becomes a "function" role
+  // 2) Tool responses -> becomes "tool" role with tool_call_id (modern format)
   if (message.role === 'tool_response') {
-    let responseContent = message.content[0]?.response;
+    const toolResponse = message.content[0];
+    let responseContent = toolResponse?.response;
     // If object, convert to string
     if (typeof responseContent === 'object') {
       responseContent = JSON.stringify(responseContent);
     }
     return {
-      role: 'function',
-      name: message.content[0]?.toolName,
+      role: 'tool',
+      tool_call_id: toolResponse?.callId || `call-${Date.now()}`,
       content: responseContent
     };
   }

--- a/lib/server.mjs
+++ b/lib/server.mjs
@@ -35,6 +35,9 @@ import documentsRouter from '../routes/charmonator/documents.mjs';
 // Charmonator tool execution endpoint
 import toolsExecuteRouter from '../routes/charmonator/tools-execute.mjs';
 
+// Charmonator markdown processing endpoint
+import markdownRouter from '../routes/charmonator/markdown.mjs';
+
 // Charmonizer routes for doc conversions, etc.
 import documentConversionsRouter from '../routes/charmonizer/document-conversion.mjs';
 
@@ -174,6 +177,7 @@ export async function createAndStart() {
     app.use(CHARMONATOR_API_PREFIX + "/documents", documentsRouter);
     app.use(CHARMONATOR_API_PREFIX + "/tools", toolsExecuteRouter);
     app.use(CHARMONATOR_API_PREFIX + "/tokens", tokensRouter);
+    app.use(CHARMONATOR_API_PREFIX + "/markdown", markdownRouter);
 
     // Mount modular apps (routes and static files)
     mountApps(app);

--- a/lib/server.mjs
+++ b/lib/server.mjs
@@ -27,6 +27,7 @@ import embeddingRouter from '../routes/embedding.mjs';
 import transcriptExtensionRouter from '../routes/transcript-extension.mjs';
 import listModelsRouter from '../routes/list-models.mjs';
 import charmonatorConversionRouter from '../routes/conversion-router.mjs';
+import tokensRouter from '../routes/tokens.mjs';
 
 // Charmonator document operations (json-doc functionality)
 import documentsRouter from '../routes/charmonator/documents.mjs';
@@ -172,6 +173,7 @@ export async function createAndStart() {
     app.use(CHARMONATOR_API_PREFIX + "/conversion", charmonatorConversionRouter);
     app.use(CHARMONATOR_API_PREFIX + "/documents", documentsRouter);
     app.use(CHARMONATOR_API_PREFIX + "/tools", toolsExecuteRouter);
+    app.use(CHARMONATOR_API_PREFIX + "/tokens", tokensRouter);
 
     // Mount modular apps (routes and static files)
     mountApps(app);

--- a/lib/server.mjs
+++ b/lib/server.mjs
@@ -27,6 +27,9 @@ import charmonatorConversionRouter from '../routes/conversion-router.mjs';
 // Charmonator document operations (json-doc functionality)
 import documentsRouter from '../routes/charmonator/documents.mjs';
 
+// Charmonator tool execution endpoint
+import toolsExecuteRouter from '../routes/charmonator/tools-execute.mjs';
+
 // Charmonizer routes for doc conversions, etc.
 import documentConversionsRouter from '../routes/charmonizer/document-conversion.mjs';
 
@@ -153,6 +156,7 @@ export async function createAndStart() {
     app.use(CHARMONATOR_API_PREFIX + "/transcript", transcriptExtensionRouter);
     app.use(CHARMONATOR_API_PREFIX + "/conversion", charmonatorConversionRouter);
     app.use(CHARMONATOR_API_PREFIX + "/documents", documentsRouter);
+    app.use(CHARMONATOR_API_PREFIX + "/tools", toolsExecuteRouter);
 
     // Mount modular apps (routes and static files)
     mountApps(app);

--- a/lib/server.mjs
+++ b/lib/server.mjs
@@ -16,6 +16,10 @@ import { setGlobalConfigFile, getConfig, getServerPort, getBaseUrl, getFullCharm
 import { loadToolDefinitionsFromConfig, initModelTools } from './tool-loader.mjs';
 import { toolRegistry } from './tools.mjs';
 
+// MCP manager for Model Context Protocol tool servers:
+import { mcpManager } from './mcp/mcp-manager.mjs';
+import { toolRuntime } from './tool-runtime.mjs';
+
 // For handling modular apps:
 import { loadAppsFromConfig, mountApps, printAppUrls } from './app-loader.mjs';
 
@@ -81,11 +85,22 @@ export async function createAndStart() {
     await initModelTools(config, definitions);
     console.log('All Registered Tools:', Array.from(toolRegistry.tools.keys()));
 
-    // 4) Load modular apps
+    // 4) Initialize MCP servers (if configured)
+    if (config.mcp && config.mcp.servers) {
+      try {
+        await mcpManager.initialize(config);
+        toolRuntime.setMCPManager(mcpManager);
+        console.log('MCP servers initialized');
+      } catch (error) {
+        console.error('MCP initialization error:', error.message);
+      }
+    }
+
+    // 5) Load modular apps
     await loadAppsFromConfig(config);
     console.log('Apps loaded successfully');
 
-    // 5) Now proceed with server setup:
+    // 6) Now proceed with server setup:
     const BASE_URL = getBaseUrl();
     const CHARMONATOR_API_PREFIX = getFullCharmonatorApiPrefix();
     const CHARMONIZER_API_PREFIX = getFullCharmonizerApiPrefix();

--- a/lib/tokenizer.mjs
+++ b/lib/tokenizer.mjs
@@ -1,0 +1,281 @@
+/**
+ * tokenizer.mjs
+ *
+ * Tokenization abstraction layer supporting both local (tiktoken) and
+ * provider API-based token counting.
+ */
+
+import { TextDecoder } from 'util';
+import { createRequire } from 'module';
+import { getModelConfig } from './config.mjs';
+import { fetchProvider } from './core.mjs';
+
+// Lazy-load tiktoken (same pattern as json-document.mjs)
+let tiktokenLib = null;
+function getTiktoken() {
+  if (!tiktokenLib) {
+    try {
+      const require = createRequire(import.meta.url);
+      tiktokenLib = require('tiktoken');
+    } catch (err) {
+      throw new Error(
+        'tiktoken library is not available. Install it with: npm install tiktoken'
+      );
+    }
+  }
+  return tiktokenLib;
+}
+
+// Encoder cache to avoid recreation
+const encoderCache = new Map();
+
+/**
+ * Supported tiktoken encodings
+ */
+const SUPPORTED_ENCODINGS = ['cl100k_base', 'o200k_base'];
+
+/**
+ * Provider-to-default-encoding mapping
+ */
+const PROVIDER_DEFAULT_ENCODINGS = {
+  'OpenAI': 'o200k_base',
+  'OpenAI_Azure': 'o200k_base',
+  'Anthropic': 'cl100k_base',
+  'Anthropic_Bedrock': 'cl100k_base',
+  'Google': 'cl100k_base',
+  'ollama': 'cl100k_base'
+};
+
+/**
+ * Model patterns for encoding selection (for OpenAI models)
+ */
+const MODEL_ENCODING_PATTERNS = [
+  { pattern: /^(gpt-4o|o1|o3|gpt-5)/i, encoding: 'o200k_base' },
+  { pattern: /^(gpt-4|gpt-3\.5|text-embedding)/i, encoding: 'cl100k_base' }
+];
+
+/**
+ * Get or create a tiktoken encoder
+ * @param {string} encodingName - The encoding name (e.g., 'cl100k_base')
+ * @returns {Object} The encoder object with encode/decode methods
+ */
+function getEncoder(encodingName) {
+  if (!encoderCache.has(encodingName)) {
+    const tiktoken = getTiktoken();
+    encoderCache.set(encodingName, tiktoken.get_encoding(encodingName));
+  }
+  return encoderCache.get(encodingName);
+}
+
+/**
+ * Resolve the tokenizer encoding to use for a given model configuration
+ * @param {Object} modelConfig - The model configuration object
+ * @returns {string} The encoding name
+ */
+export function resolveTokenizer(modelConfig) {
+  // 1. Explicit tokenizer in config takes precedence
+  if (modelConfig.tokenizer) {
+    return modelConfig.tokenizer;
+  }
+
+  // 2. Infer from model name patterns
+  const modelName = modelConfig.model || '';
+  for (const { pattern, encoding } of MODEL_ENCODING_PATTERNS) {
+    if (pattern.test(modelName)) {
+      return encoding;
+    }
+  }
+
+  // 3. Fall back to provider default
+  return PROVIDER_DEFAULT_ENCODINGS[modelConfig.api] || 'cl100k_base';
+}
+
+/**
+ * Resolve the tokenizer mode (local vs api)
+ * @param {Object} modelConfig - The model configuration object
+ * @returns {string} Either 'local' or 'api'
+ */
+export function resolveTokenizerMode(modelConfig) {
+  return modelConfig.tokenizer_mode || 'local';
+}
+
+/**
+ * Tokenize text locally using tiktoken
+ * @param {string} text - The text to tokenize
+ * @param {string} [encodingName='cl100k_base'] - The encoding to use
+ * @returns {number[]} Array of token IDs
+ */
+export function tokenizeLocal(text, encodingName = 'cl100k_base') {
+  const enc = getEncoder(encodingName);
+  const tokens = enc.encode(text);
+  return Array.from(tokens);
+}
+
+/**
+ * Convert token IDs to their string representations
+ * @param {number[]} tokens - Array of token IDs
+ * @param {string} [encodingName='cl100k_base'] - The encoding to use
+ * @returns {string[]} Array of token strings
+ */
+export function decodeTokensToStrings(tokens, encodingName = 'cl100k_base') {
+  const enc = getEncoder(encodingName);
+  const decoder = new TextDecoder('utf-8', { fatal: false });
+
+  return tokens.map(token => {
+    try {
+      const bytes = enc.decode_single_token_bytes(token);
+      return decoder.decode(bytes);
+    } catch (err) {
+      // Fallback for tokens that don't decode cleanly
+      return `<token:${token}>`;
+    }
+  });
+}
+
+/**
+ * Count tokens locally using tiktoken
+ * @param {string} text - The text to count tokens in
+ * @param {string} [encodingName='cl100k_base'] - The encoding to use
+ * @returns {number} The token count
+ */
+export function countTokensLocal(text, encodingName = 'cl100k_base') {
+  const tokens = tokenizeLocal(text, encodingName);
+  return tokens.length;
+}
+
+/**
+ * Count tokens using provider API (when available)
+ * @param {string} text - The text to count tokens in
+ * @param {string} modelName - The model name to look up
+ * @returns {Promise<number>} The token count
+ */
+export async function countTokensAPI(text, modelName) {
+  const provider = fetchProvider(modelName);
+
+  if (typeof provider.countTokens === 'function') {
+    return await provider.countTokens(text);
+  }
+
+  // Fallback to local counting if provider doesn't support API counting
+  const modelConfig = getModelConfig(modelName);
+  const encoding = resolveTokenizer(modelConfig);
+  return countTokensLocal(text, encoding);
+}
+
+/**
+ * Get list of supported tokenizer encodings
+ * @returns {string[]} Array of supported encoding names
+ */
+export function getSupportedEncodings() {
+  return [...SUPPORTED_ENCODINGS];
+}
+
+/**
+ * Check if an encoding name is supported
+ * @param {string} encodingName - The encoding name to check
+ * @returns {boolean} True if supported
+ */
+export function isValidEncoding(encodingName) {
+  return SUPPORTED_ENCODINGS.includes(encodingName);
+}
+
+/**
+ * Main tokenization function - handles both modes
+ * @param {string} text - The text to tokenize
+ * @param {Object} [options={}] - Options object
+ * @param {string} [options.tokenizer] - Explicit tokenizer encoding name
+ * @param {string} [options.model] - Model name to look up tokenizer from config
+ * @returns {Promise<Object>} Result with tokens, encoding, and mode
+ */
+export async function tokenize(text, options = {}) {
+  const { tokenizer, model } = options;
+
+  if (tokenizer) {
+    // Explicit tokenizer requested
+    const tokens = tokenizeLocal(text, tokenizer);
+    return {
+      tokens: decodeTokensToStrings(tokens, tokenizer),
+      encoding: tokenizer,
+      mode: 'local'
+    };
+  }
+
+  if (model) {
+    const modelConfig = getModelConfig(model);
+    const encoding = resolveTokenizer(modelConfig);
+    const mode = resolveTokenizerMode(modelConfig);
+
+    if (mode === 'api') {
+      // API mode doesn't support returning individual tokens
+      throw new Error(
+        'API mode does not support returning individual tokens. Use /tokens/count instead, or set tokenizer_mode to "local" in model config.'
+      );
+    }
+
+    const tokens = tokenizeLocal(text, encoding);
+    return {
+      tokens: decodeTokensToStrings(tokens, encoding),
+      encoding,
+      mode: 'local'
+    };
+  }
+
+  // Default to cl100k_base
+  const defaultEncoding = 'cl100k_base';
+  const tokens = tokenizeLocal(text, defaultEncoding);
+  return {
+    tokens: decodeTokensToStrings(tokens, defaultEncoding),
+    encoding: defaultEncoding,
+    mode: 'local'
+  };
+}
+
+/**
+ * Main token counting function - handles both modes
+ * @param {string} text - The text to count tokens in
+ * @param {Object} [options={}] - Options object
+ * @param {string} [options.tokenizer] - Explicit tokenizer encoding name
+ * @param {string} [options.model] - Model name to look up tokenizer from config
+ * @returns {Promise<Object>} Result with count, encoding, and mode
+ */
+export async function countTokens(text, options = {}) {
+  const { tokenizer, model } = options;
+
+  if (tokenizer) {
+    // Explicit tokenizer - always local
+    return {
+      count: countTokensLocal(text, tokenizer),
+      encoding: tokenizer,
+      mode: 'local'
+    };
+  }
+
+  if (model) {
+    const modelConfig = getModelConfig(model);
+    const encoding = resolveTokenizer(modelConfig);
+    const mode = resolveTokenizerMode(modelConfig);
+
+    if (mode === 'api') {
+      const count = await countTokensAPI(text, model);
+      return {
+        count,
+        encoding: null, // API doesn't expose encoding
+        mode: 'api'
+      };
+    }
+
+    return {
+      count: countTokensLocal(text, encoding),
+      encoding,
+      mode: 'local'
+    };
+  }
+
+  // Default
+  const defaultEncoding = 'cl100k_base';
+  return {
+    count: countTokensLocal(text, defaultEncoding),
+    encoding: defaultEncoding,
+    mode: 'local'
+  };
+}

--- a/lib/tool-definition.mjs
+++ b/lib/tool-definition.mjs
@@ -1,0 +1,84 @@
+// tool-definition.mjs
+// Defines tool kinds and a unified ToolDefinition structure
+
+/**
+ * Tool execution domains
+ */
+export const ToolKind = {
+  SERVER: 'server',   // Executed on the server
+  CLIENT: 'client',   // Executed by the client (schema only on server)
+  MCP: 'mcp'          // Executed via MCP server proxy
+};
+
+/**
+ * Unified tool definition that supports all tool kinds
+ */
+export class ToolDefinition {
+  /**
+   * @param {Object} config - Tool configuration
+   * @param {string} config.kind - Tool kind (server, client, mcp)
+   * @param {string} config.name - Tool name (model-visible)
+   * @param {string} config.description - Tool description
+   * @param {Object} config.input_schema - JSON Schema for tool inputs
+   * @param {Function} [config.run] - Execution function (server/mcp only)
+   * @param {Object} [config.meta] - Additional metadata
+   */
+  constructor({ kind, name, description, input_schema, run, meta }) {
+    this.kind = kind || ToolKind.SERVER;
+    this.name = name;
+    this.description = description;
+    this.input_schema = input_schema;
+    this.run = run;  // undefined for client tools
+    this.meta = meta || {};
+  }
+
+  /**
+   * Check if this tool can be executed on the server
+   * @returns {boolean}
+   */
+  isExecutable() {
+    return this.kind !== ToolKind.CLIENT;
+  }
+
+  /**
+   * Check if this is a client-side tool
+   * @returns {boolean}
+   */
+  isClient() {
+    return this.kind === ToolKind.CLIENT;
+  }
+
+  /**
+   * Check if this is an MCP tool
+   * @returns {boolean}
+   */
+  isMCP() {
+    return this.kind === ToolKind.MCP;
+  }
+
+  /**
+   * Convert to provider-friendly format (for API calls)
+   * @returns {Object}
+   */
+  toProviderFormat() {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: this.input_schema
+    };
+  }
+
+  /**
+   * Convert to JSON-serializable format
+   * @returns {Object}
+   */
+  toJSON() {
+    return {
+      kind: this.kind,
+      name: this.name,
+      description: this.description,
+      input_schema: this.input_schema,
+      meta: this.meta
+    };
+  }
+}

--- a/lib/tool-loader.mjs
+++ b/lib/tool-loader.mjs
@@ -1,59 +1,253 @@
 /**
  * tool-loader.mjs
  *
- * Implements a config-driven tool loader. Tools can be declared as single tools
- * or as “toolboxes” (lists of references to other tools).
+ * Implements a config-driven tool loader supporting both legacy and new formats.
  *
- * Usage in your startup code:
- *
- *   import { loadToolDefinitionsFromConfig, initModelTools } from './tool-loader.mjs';
- *   import { getConfig } from './config.mjs';
- *
- *   async function startup() {
- *     const config = getConfig();
- *     const toolDefs = loadToolDefinitionsFromConfig(config);
- *     // For each model, expand & instantiate its tools:
- *     await initModelTools(config, toolDefs);
+ * NEW FORMAT (toolbox-based):
+ * {
+ *   "toolboxes": {
+ *     "builtins": { "code": "./tools/builtins.mjs" }
+ *   },
+ *   "tools": {
+ *     "server": {
+ *       "calculator": { "from": "builtins", "export": "CalculatorTool", "options": {} }
+ *     },
+ *     "client": {
+ *       "open_file": { "from": "client_tools", "export": "OpenFileTool" }
+ *     }
+ *   },
+ *   "models": {
+ *     "gpt-4o": {
+ *       "tools": { "server": ["calculator"], "client": [], "mcp": [] }
+ *     }
  *   }
+ * }
  *
+ * LEGACY FORMAT (still supported):
+ * {
+ *   "tools": {
+ *     "web_search": { "code": "./tools/web_search.mjs", "class": "WebSearchTool" },
+ *     "my_box": { "toolbox": ["web_search"] }
+ *   },
+ *   "models": {
+ *     "gpt-4o": { "tools": ["web_search", "my_box"] }
+ *   }
+ * }
  */
 
-import fs from 'fs/promises';
-
-// EXAMPLE: If you want to use the toolRegistry from your code:
+import { pathToFileURL, fileURLToPath } from 'url';
+import path from 'path';
 import { toolRegistry } from './tools.mjs';
+import { ToolKind, ToolDefinition } from './tool-definition.mjs';
+
+// Get the charmonator root directory (parent of lib/)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CHARMONATOR_ROOT = path.resolve(__dirname, '..');
+
+// Cache for loaded toolbox modules
+const toolboxCache = new Map();
 
 /**
- * Parse out the top-level `config.tools` object, returning a map of
- *  toolName -> { type: 'single' | 'toolbox', [loaderConfig], [childRefs] }
- *
- * In your `config.json`, you might have something like:
- *  {
- *    "tools": {
- *      "web_search": {
- *        "package": "my-tool-lib",
- *        "class": "WebSearchTool",
- *        "options": { ... }
- *      },
- *      "calc": { "code": "./tools/calculator.js" },
- *      "my_box": { "toolbox": ["web_search", "calc"] }
- *    }
- *  }
+ * Detect if config uses new format (has toolboxes or tools.server/tools.client)
+ */
+function isNewFormat(config) {
+  return config.toolboxes ||
+         (config.tools && (config.tools.server || config.tools.client));
+}
+
+// ============================================================================
+// NEW FORMAT LOADERS
+// ============================================================================
+
+/**
+ * Load all toolbox modules from config
+ * @param {Object} config - Full config object
+ */
+export async function loadToolboxes(config) {
+  const toolboxes = config.toolboxes || {};
+
+  for (const [boxId, boxConfig] of Object.entries(toolboxes)) {
+    try {
+      let modulePath = boxConfig.code || boxConfig.package;
+
+      // Handle relative paths (resolve from charmonator root, not cwd)
+      if (modulePath.startsWith('./') || modulePath.startsWith('../')) {
+        modulePath = pathToFileURL(path.resolve(CHARMONATOR_ROOT, modulePath)).href;
+      }
+
+      const mod = await import(modulePath);
+      toolboxCache.set(boxId, {
+        module: mod,
+        options: boxConfig.options || {}
+      });
+      console.log(`[ToolLoader] Loaded toolbox: ${boxId}`);
+    } catch (error) {
+      console.error(`[ToolLoader] Failed to load toolbox ${boxId}:`, error.message);
+    }
+  }
+}
+
+/**
+ * Load server tools from config.tools.server
+ * @param {Object} config - Full config object
+ */
+export async function loadServerTools(config) {
+  const serverTools = config.tools?.server || {};
+
+  for (const [toolId, toolConfig] of Object.entries(serverTools)) {
+    await loadToolFromConfig(toolId, toolConfig, ToolKind.SERVER);
+  }
+}
+
+/**
+ * Load client tools from config.tools.client
+ * (These are schema-only on the server, but we register them for reference)
+ * @param {Object} config - Full config object
+ */
+export async function loadClientTools(config) {
+  const clientTools = config.tools?.client || {};
+
+  for (const [toolId, toolConfig] of Object.entries(clientTools)) {
+    await loadToolFromConfig(toolId, toolConfig, ToolKind.CLIENT);
+  }
+}
+
+/**
+ * Load a single tool from toolbox-based config
+ * @param {string} toolId - Tool identifier in config
+ * @param {Object} toolConfig - Tool configuration { from, export, options, toolName }
+ * @param {string} kind - Tool kind (server, client, mcp)
+ */
+async function loadToolFromConfig(toolId, toolConfig, kind) {
+  const { from: boxId, export: exportName, options, toolName } = toolConfig;
+
+  const box = toolboxCache.get(boxId);
+  if (!box) {
+    console.error(`[ToolLoader] Toolbox not found: ${boxId} (for tool ${toolId})`);
+    return;
+  }
+
+  const ToolExport = box.module[exportName];
+  if (!ToolExport) {
+    console.error(`[ToolLoader] Export ${exportName} not found in toolbox ${boxId}`);
+    return;
+  }
+
+  // Merge toolbox options with tool-specific options
+  const mergedOptions = { ...box.options, ...options };
+
+  let toolDef;
+  try {
+    if (typeof ToolExport === 'function') {
+      // Could be a class constructor or factory function
+      try {
+        // Try as class constructor
+        const instance = new ToolExport(mergedOptions);
+        toolDef = new ToolDefinition({
+          kind,
+          name: toolName || instance.name || toolId,
+          description: instance.description,
+          input_schema: instance.input_schema,
+          run: kind !== ToolKind.CLIENT ? instance.run?.bind(instance) : undefined,
+          meta: { toolId, source: 'config', options: mergedOptions }
+        });
+      } catch (e) {
+        // Try as factory function
+        const instance = ToolExport(mergedOptions);
+        if (instance && instance.input_schema) {
+          toolDef = new ToolDefinition({
+            kind,
+            name: toolName || instance.name || toolId,
+            description: instance.description,
+            input_schema: instance.input_schema,
+            run: kind !== ToolKind.CLIENT ? instance.run : undefined,
+            meta: { toolId, source: 'config', options: mergedOptions }
+          });
+        }
+      }
+    } else if (typeof ToolExport === 'object' && ToolExport.input_schema) {
+      // Plain descriptor object
+      toolDef = new ToolDefinition({
+        kind,
+        name: toolName || ToolExport.name || toolId,
+        description: ToolExport.description,
+        input_schema: ToolExport.input_schema,
+        run: kind !== ToolKind.CLIENT ? ToolExport.run : undefined,
+        meta: { toolId, source: 'config', options: mergedOptions }
+      });
+    }
+
+    if (toolDef) {
+      toolRegistry.register(toolDef);
+      console.log(`[ToolLoader] Registered ${kind} tool: ${toolDef.name}`);
+    }
+  } catch (error) {
+    console.error(`[ToolLoader] Error loading tool ${toolId}:`, error.message);
+  }
+}
+
+/**
+ * Initialize all tools using the new format
+ * @param {Object} config - Full config object
+ */
+export async function initAllToolsNewFormat(config) {
+  await loadToolboxes(config);
+  await loadServerTools(config);
+  await loadClientTools(config);
+  // MCP tools are loaded by MCPManager separately
+}
+
+/**
+ * Validate and expand model tool references for new format
+ * @param {Object} config - Full config object
+ */
+export function validateModelToolRefs(config) {
+  if (!config.models) return;
+
+  for (const [modelName, modelCfg] of Object.entries(config.models)) {
+    if (typeof modelCfg === 'string') continue; // Skip aliases
+
+    const toolRefs = modelCfg.tools || {};
+    const serverRefs = toolRefs.server || toolRefs || []; // Fallback to flat array
+    const clientRefs = toolRefs.client || [];
+    const mcpRefs = toolRefs.mcp || [];
+
+    // Validate each reference exists
+    for (const ref of [...serverRefs, ...clientRefs, ...mcpRefs]) {
+      if (typeof ref === 'string' && !toolRegistry.getTool(ref)) {
+        console.warn(`[ToolLoader] Model "${modelName}" references unknown tool: ${ref}`);
+      }
+    }
+  }
+}
+
+// ============================================================================
+// LEGACY FORMAT LOADERS (for backward compatibility)
+// ============================================================================
+
+/**
+ * Parse out the top-level `config.tools` object (legacy format)
  */
 export function loadToolDefinitionsFromConfig(config) {
+  // Check for new format first
+  if (isNewFormat(config)) {
+    // Return empty map - new format uses different flow
+    return new Map();
+  }
+
   const toolEntries = config.tools || {};
-  const definitions = new Map();  // toolName => metadata object
+  const definitions = new Map();
 
   for (const [toolName, toolConf] of Object.entries(toolEntries)) {
     if (toolConf.toolbox) {
       // This entry is a "toolbox" containing an array of child names
       definitions.set(toolName, {
         type: 'toolbox',
-        childRefs: toolConf.toolbox   // array of strings
+        childRefs: toolConf.toolbox
       });
     } else {
       // This entry is a "single" tool definition
-      // We'll store the entire object in `loaderConfig` for later instantiation
       definitions.set(toolName, {
         type: 'single',
         loaderConfig: toolConf
@@ -64,12 +258,7 @@ export function loadToolDefinitionsFromConfig(config) {
 }
 
 /**
- * Expand a tool reference that might be a single tool or a toolbox.
- *
- * If it’s a toolbox, recursively gather all child tools. If it’s a single tool, return [toolName].
- * This ensures that a reference to e.g. "my_box" expands to ["web_search", "calc", ...].
- *
- * We pass in a `visited` set to detect cycles.
+ * Expand a tool reference that might be a single tool or a toolbox (legacy format)
  */
 export function expandToolRefs(toolName, definitions, visited = new Set()) {
   if (visited.has(toolName)) {
@@ -90,38 +279,20 @@ export function expandToolRefs(toolName, definitions, visited = new Set()) {
     }
     return expanded;
   } else {
-    // Single
     return [toolName];
   }
 }
 
 /**
- * Dynamically instantiate a single tool from its loaderConfig.
- *
- * For example:
- *   {
- *     "package": "my-tool-lib",
- *     "class": "WebSearchTool",
- *     "options": { "default_api": "duckduckgo" }
- *   }
- * or
- *   {
- *     "code": "./tools/calculator.js",
- *     "class": "CalculatorTool",
- *     "options": { "precision": 8 }
- *   }
- *
- * Return a new instance of `BaseTool` (or SessionTool, etc.).
+ * Dynamically instantiate a single tool from its loaderConfig (legacy format)
  */
 export async function instantiateToolFromLoaderConfig(loaderConfig) {
-  // We’ll look for recognized fields: package, code, class, options
   const { package: pkg, code, class: className, options } = loaderConfig;
 
   let ToolClass = null;
 
   if (pkg) {
-    // e.g. "my-tool-lib"
-    const mod = await import(pkg);       // dynamic import
+    const mod = await import(pkg);
     if (!className) {
       throw new Error(`loaderConfig requires "class" when using "package". config=${JSON.stringify(loaderConfig)}`);
     }
@@ -131,15 +302,18 @@ export async function instantiateToolFromLoaderConfig(loaderConfig) {
     }
   }
   else if (code) {
-    // e.g. "./tools/calculator.js"
-    const mod = await import(code);
+    let modulePath = code;
+    // Resolve relative paths from charmonator root, not cwd
+    if (code.startsWith('./') || code.startsWith('../')) {
+      modulePath = pathToFileURL(path.resolve(CHARMONATOR_ROOT, code)).href;
+    }
+    const mod = await import(modulePath);
     if (className) {
       ToolClass = mod[className];
       if (!ToolClass) {
         throw new Error(`No export named "${className}" in file "${code}"`);
       }
     } else if (mod.default) {
-      // fallback: use default export
       ToolClass = mod.default;
     } else {
       throw new Error(`No "class" specified, and no default export found in "${code}"`);
@@ -149,62 +323,91 @@ export async function instantiateToolFromLoaderConfig(loaderConfig) {
     throw new Error(`Tool loaderConfig must have either "package" or "code". config=${JSON.stringify(loaderConfig)}`);
   }
 
-  // Now create instance
   const instance = new ToolClass(options);
-  // Optionally do more checks, e.g. verifying instance is a subclass of your BaseTool
+  // Set default kind to server for legacy tools
+  if (!instance.kind) {
+    instance.kind = ToolKind.SERVER;
+  }
   return instance;
 }
 
 /**
- * For each model in the config, gather the tool references from `modelCfg.tools`,
- * expand them (in case of toolboxes), instantiate them, and register them in the toolRegistry.
- *
- * You can also store the actual tool instances in `modelCfg._resolvedTools` if you want direct references.
+ * For each model in the config, gather and instantiate tools (legacy format)
  */
 export async function initModelTools(config, definitions) {
+  // Check for new format first
+  if (isNewFormat(config)) {
+    await initAllToolsNewFormat(config);
+    validateModelToolRefs(config);
+    return;
+  }
+
+  // Legacy format processing
   if (!config.models) return;
 
   for (const [modelName, modelCfg] of Object.entries(config.models)) {
-    // Skip model aliases (strings that reference other models)
     if (typeof modelCfg === 'string') {
       continue;
     }
     const toolRefs = modelCfg.tools || [];
     let finalToolNames = [];
 
-    // Expand each ref to a list of single tool names
     for (const refName of toolRefs) {
       const expanded = expandToolRefs(refName, definitions);
       finalToolNames = finalToolNames.concat(expanded);
     }
-    // Deduplicate
     finalToolNames = [...new Set(finalToolNames)];
 
-    // Instantiate & register
     const instantiatedTools = [];
+    const loadedToolNames = [];
     for (const tName of finalToolNames) {
       const def = definitions.get(tName);
       if (!def) {
-        // means config is inconsistent
-        throw new Error(`No definition for tool "${tName}" (model="${modelName}")`);
+        console.warn(`[ToolLoader] No definition for tool "${tName}" (model="${modelName}"), skipping`);
+        continue;
       }
       if (def.type !== 'single') {
-        // shouldn't happen if expandToolRefs worked
         continue;
       }
 
-      // Actually build the tool
-      const toolObj = await instantiateToolFromLoaderConfig(def.loaderConfig);
-
-      // Register in your global tool registry
-      // so that chatModel.enableTool(tName) can find it
-      toolRegistry.register(toolObj);
-
-      instantiatedTools.push(toolObj);
+      try {
+        const toolObj = await instantiateToolFromLoaderConfig(def.loaderConfig);
+        toolRegistry.register(toolObj);
+        instantiatedTools.push(toolObj);
+        loadedToolNames.push(tName);
+      } catch (error) {
+        console.warn(`[ToolLoader] Failed to load tool "${tName}": ${error.message}`);
+      }
     }
 
-    // If you like, store them on the model config for reference:
     modelCfg._resolvedTools = instantiatedTools;
-    console.log(`Model "${modelName}" loaded tools:`, finalToolNames);
+    if (loadedToolNames.length > 0) {
+      console.log(`Model "${modelName}" loaded tools:`, loadedToolNames);
+    }
   }
+}
+
+// ============================================================================
+// UNIFIED ENTRY POINT
+// ============================================================================
+
+/**
+ * Initialize all tools from config (handles both new and legacy formats)
+ * @param {Object} config - Full config object
+ */
+export async function initAllTools(config) {
+  if (isNewFormat(config)) {
+    await initAllToolsNewFormat(config);
+    validateModelToolRefs(config);
+  } else {
+    const definitions = loadToolDefinitionsFromConfig(config);
+    await initModelTools(config, definitions);
+  }
+}
+
+/**
+ * Clear the toolbox cache (for testing)
+ */
+export function clearToolboxCache() {
+  toolboxCache.clear();
 }

--- a/lib/tool-runtime.mjs
+++ b/lib/tool-runtime.mjs
@@ -66,9 +66,8 @@ export class ToolRuntime {
           if (!this.mcpManager) {
             throw new Error('MCP manager not configured');
           }
-          const mcpServer = tool.meta?.mcpServer;
-          const mcpTool = tool.meta?.mcpTool || tool.name;
-          result = await this.mcpManager.callTool(mcpServer, mcpTool, args);
+          // The MCP manager looks up the server from its internal mapping
+          result = await this.mcpManager.callTool(toolName, args);
         } else {
           // Server tools are executed directly
           result = await tool.run(args);

--- a/lib/tool-runtime.mjs
+++ b/lib/tool-runtime.mjs
@@ -1,0 +1,141 @@
+// tool-runtime.mjs
+// Central dispatcher for tool execution
+
+import { toolRegistry } from './tools.mjs';
+import { ToolKind } from './tool-definition.mjs';
+
+/**
+ * ToolRuntime handles explicit tool execution for server/MCP tools.
+ * This is used by the /v1/tools/execute endpoint when clients need to
+ * execute server-side tools after receiving a client tool call response.
+ */
+export class ToolRuntime {
+  /**
+   * @param {Object} [mcpManager] - Optional MCP manager for proxying MCP tool calls
+   */
+  constructor(mcpManager = null) {
+    this.mcpManager = mcpManager;
+  }
+
+  /**
+   * Set the MCP manager (for late binding after MCP initialization)
+   * @param {Object} mcpManager - The MCP manager instance
+   */
+  setMCPManager(mcpManager) {
+    this.mcpManager = mcpManager;
+  }
+
+  /**
+   * Execute an array of tool calls
+   * @param {Array} toolCalls - Array of tool call objects with toolName, callId, arguments
+   * @returns {Promise<Array>} Array of tool response objects
+   */
+  async executeToolCalls(toolCalls) {
+    const responses = [];
+
+    for (const call of toolCalls) {
+      const { toolName, callId, arguments: args } = call;
+
+      // Look up the tool
+      const tool = toolRegistry.getTool(toolName);
+
+      if (!tool) {
+        responses.push({
+          toolName,
+          callId,
+          error: `Tool not found: ${toolName}`
+        });
+        continue;
+      }
+
+      // Reject client tools - they should be executed by the client
+      if (tool.kind === ToolKind.CLIENT) {
+        responses.push({
+          toolName,
+          callId,
+          error: 'Client tools cannot be executed on the server'
+        });
+        continue;
+      }
+
+      try {
+        let result;
+
+        if (tool.kind === ToolKind.MCP) {
+          // MCP tools are proxied through the MCP manager
+          if (!this.mcpManager) {
+            throw new Error('MCP manager not configured');
+          }
+          const mcpServer = tool.meta?.mcpServer;
+          const mcpTool = tool.meta?.mcpTool || tool.name;
+          result = await this.mcpManager.callTool(mcpServer, mcpTool, args);
+        } else {
+          // Server tools are executed directly
+          result = await tool.run(args);
+        }
+
+        responses.push({
+          toolName,
+          callId,
+          content: typeof result === 'string' ? result : JSON.stringify(result)
+        });
+      } catch (error) {
+        console.error(`[ToolRuntime] Error executing tool ${toolName}:`, error);
+        responses.push({
+          toolName,
+          callId,
+          error: error.message
+        });
+      }
+    }
+
+    return responses;
+  }
+
+  /**
+   * Execute a single tool call
+   * @param {string} toolName - Name of the tool
+   * @param {string} callId - Unique call identifier
+   * @param {Object} args - Tool arguments
+   * @returns {Promise<Object>} Tool response object
+   */
+  async executeTool(toolName, callId, args) {
+    const responses = await this.executeToolCalls([{ toolName, callId, arguments: args }]);
+    return responses[0];
+  }
+
+  /**
+   * Check if a tool exists and is executable on the server
+   * @param {string} toolName - Name of the tool
+   * @returns {boolean} True if tool exists and is server/MCP kind
+   */
+  canExecute(toolName) {
+    const tool = toolRegistry.getTool(toolName);
+    return tool && tool.kind !== ToolKind.CLIENT;
+  }
+
+  /**
+   * Get list of all executable (server/MCP) tools
+   * @returns {Array} Array of tool definitions
+   */
+  getExecutableTools() {
+    const serverTools = toolRegistry.getToolsByKind(ToolKind.SERVER);
+    const mcpTools = toolRegistry.getToolsByKind(ToolKind.MCP);
+
+    return [
+      ...Array.from(serverTools.values()).map(t => t.toProviderFormat?.() || {
+        name: t.name,
+        description: t.description,
+        input_schema: t.input_schema
+      }),
+      ...Array.from(mcpTools.values()).map(t => t.toProviderFormat?.() || {
+        name: t.name,
+        description: t.description,
+        input_schema: t.input_schema
+      })
+    ];
+  }
+}
+
+// Singleton instance
+export const toolRuntime = new ToolRuntime();

--- a/lib/tools.mjs
+++ b/lib/tools.mjs
@@ -1,15 +1,38 @@
 // tools.mjs
 
-
+import { ToolKind } from './tool-definition.mjs';
 
 /**
  * Base class for all tools
  */
 export class BaseTool {
-  constructor(name, description, inputSchema) {
+  /**
+   * @param {string} name - Tool name
+   * @param {string} description - Tool description
+   * @param {Object} inputSchema - JSON Schema for tool inputs
+   * @param {string} [kind='server'] - Tool kind (server, client, mcp)
+   */
+  constructor(name, description, inputSchema, kind = ToolKind.SERVER) {
     this.name = name;
     this.description = description;
     this.input_schema = inputSchema;
+    this.kind = kind;
+  }
+
+  /**
+   * Check if this tool can be executed on the server
+   * @returns {boolean}
+   */
+  isExecutable() {
+    return this.kind !== ToolKind.CLIENT;
+  }
+
+  /**
+   * Check if this is a client-side tool
+   * @returns {boolean}
+   */
+  isClient() {
+    return this.kind === ToolKind.CLIENT;
   }
 
   /**
@@ -42,66 +65,6 @@ export class StatelessTool extends BaseTool {
   }
 }
 
-/**
- * Session-bound tool that maintains state within a chat session
- */
-export class SessionTool extends BaseTool {
-  /**
-   * @param {string} name - Tool name
-   * @param {string} description - Tool description
-   * @param {Object} inputSchema - JSON Schema for tool inputs
-   * @param {Function} func - Function to execute (will be bound to session)
-   */
-  constructor(name, description, inputSchema, func) {
-    super(name, description, inputSchema);
-    this.func = func;
-    this._boundSessions = new WeakMap(); // Store session-bound functions
-  }
-
-  /**
-   * Bind this tool to a specific chat session
-   * @param {ChatSession} session - The chat session to bind to
-   * @returns {SessionTool} This tool instance
-   */
-  bindSession(session) {
-    // Create a context object that will be 'this' in the function
-    const context = {
-      session,
-      getSessionData: () => {
-        if (!session.toolData) {
-          session.toolData = new Map();
-        }
-        if (!session.toolData.has(this.name)) {
-          session.toolData.set(this.name, {});
-        }
-        return session.toolData.get(this.name);
-      }
-    };
-
-    // Store the bound function in our WeakMap
-    this._boundSessions.set(session, this.func.bind(context));
-    return this;
-  }
-
-  /**
-   * Run the tool in the context of its bound session
-   * @param {Object} args - Tool arguments
-   * @param {ChatSession} session - The chat session making the call
-   * @returns {Promise<any>} Tool result
-   */
-  async run(args, session) {
-    if (!session) {
-      throw new Error('SessionTool requires a session to run');
-    }
-
-    const boundFunc = this._boundSessions.get(session);
-    if (!boundFunc) {
-      throw new Error('Tool not bound to this session');
-    }
-
-    return await boundFunc(args);
-  }
-}
 
 /**
  * Global registry for tools
@@ -128,36 +91,51 @@ class ToolRegistry {
   /**
    * Get a tool by name
    * @param {string} name - Tool name
-   * @returns {BaseTool} The requested too, or null if not found
+   * @returns {BaseTool} The requested tool, or null if not found
    */
   getTool(name) {
     const tool = this.tools.get(name);
-    /*
-    if (!tool) {
-      throw new Error(`Tool ${name} not found`);
-    }
-    */
     return tool;
   }
 
   /**
-   * Create a session-specific copy of tools
-   * @param {ChatSession} session - The chat session to bind tools to
-   * @returns {Map<string, BaseTool>} Map of tool names to bound tools
+   * Get all tools of a specific kind
+   * @param {string} kind - Tool kind (server, client, mcp)
+   * @returns {Map<string, BaseTool>} Map of tools with the specified kind
    */
-  getSessionTools(session) {
-    const sessionTools = new Map();
-    
+  getToolsByKind(kind) {
+    const result = new Map();
     for (const [name, tool] of this.tools) {
-      if (tool instanceof SessionTool) {
-        sessionTools.set(name, tool.bindSession(session));
-      } else {
-        sessionTools.set(name, tool);
+      if (tool.kind === kind) {
+        result.set(name, tool);
       }
     }
-    
-    return sessionTools;
+    return result;
   }
+
+  /**
+   * Check if any of the given tool names are client tools
+   * @param {string[]} toolNames - Array of tool names to check
+   * @returns {boolean} True if any tool is a client tool
+   */
+  hasClientTools(toolNames) {
+    for (const name of toolNames) {
+      const tool = this.tools.get(name);
+      if (tool && tool.kind === ToolKind.CLIENT) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Get all registered tool names
+   * @returns {string[]} Array of tool names
+   */
+  getAllToolNames() {
+    return Array.from(this.tools.keys());
+  }
+
 }
 
 // Export singleton instance

--- a/mcp-servers/test-server.mjs
+++ b/mcp-servers/test-server.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+/**
+ * test-server.mjs
+ *
+ * A test MCP (Model Context Protocol) server for development and testing.
+ *
+ * Provides the following tools:
+ * - echo: Echo back an input message
+ * - calculator: Basic arithmetic operations
+ * - read_file: Read file contents
+ * - write_file: Write content to a temp file
+ *
+ * Usage:
+ *   node mcp-servers/test-server.mjs
+ *
+ * Communication:
+ *   Uses stdio transport (JSON-RPC over stdin/stdout)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as readline from 'readline';
+
+// Server information
+const SERVER_INFO = {
+  name: 'test-mcp-server',
+  version: '1.0.0'
+};
+
+// Tool definitions
+const TOOLS = [
+  {
+    name: 'echo',
+    description: 'Echo back the provided message',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          description: 'The message to echo back'
+        }
+      },
+      required: ['message']
+    }
+  },
+  {
+    name: 'calculator',
+    description: 'Perform basic arithmetic operations: add, subtract, multiply, divide',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operation: {
+          type: 'string',
+          enum: ['add', 'subtract', 'multiply', 'divide'],
+          description: 'The arithmetic operation to perform'
+        },
+        a: {
+          type: 'number',
+          description: 'First operand'
+        },
+        b: {
+          type: 'number',
+          description: 'Second operand'
+        }
+      },
+      required: ['operation', 'a', 'b']
+    }
+  },
+  {
+    name: 'read_file',
+    description: 'Read the contents of a file',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Path to the file to read'
+        },
+        encoding: {
+          type: 'string',
+          description: 'File encoding (default: utf-8)',
+          enum: ['utf-8', 'ascii', 'base64']
+        }
+      },
+      required: ['path']
+    }
+  },
+  {
+    name: 'write_file',
+    description: 'Write content to a file in the temp directory',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        filename: {
+          type: 'string',
+          description: 'Name for the temp file'
+        },
+        content: {
+          type: 'string',
+          description: 'Content to write to the file'
+        }
+      },
+      required: ['filename', 'content']
+    }
+  }
+];
+
+// Tool implementations
+const TOOL_HANDLERS = {
+  echo: async (args) => {
+    return { message: args.message };
+  },
+
+  calculator: async (args) => {
+    const { operation, a, b } = args;
+
+    let result;
+    switch (operation) {
+      case 'add':
+        result = a + b;
+        break;
+      case 'subtract':
+        result = a - b;
+        break;
+      case 'multiply':
+        result = a * b;
+        break;
+      case 'divide':
+        if (b === 0) {
+          throw new Error('Division by zero');
+        }
+        result = a / b;
+        break;
+      default:
+        throw new Error(`Unknown operation: ${operation}`);
+    }
+
+    return { operation, a, b, result };
+  },
+
+  read_file: async (args) => {
+    const filePath = args.path;
+    const encoding = args.encoding || 'utf-8';
+
+    try {
+      const content = fs.readFileSync(filePath, encoding);
+      return {
+        path: filePath,
+        content: content,
+        size: content.length
+      };
+    } catch (error) {
+      throw new Error(`Failed to read file: ${error.message}`);
+    }
+  },
+
+  write_file: async (args) => {
+    const { filename, content } = args;
+
+    // Write to temp directory for safety
+    const tempDir = os.tmpdir();
+    const safeName = path.basename(filename);  // Prevent path traversal
+    const filePath = path.join(tempDir, `mcp-test-${safeName}`);
+
+    try {
+      fs.writeFileSync(filePath, content, 'utf-8');
+      return {
+        path: filePath,
+        size: content.length,
+        success: true
+      };
+    } catch (error) {
+      throw new Error(`Failed to write file: ${error.message}`);
+    }
+  }
+};
+
+/**
+ * MCP Server class
+ */
+class MCPServer {
+  constructor() {
+    this.initialized = false;
+    this.capabilities = {};
+  }
+
+  /**
+   * Handle incoming JSON-RPC messages
+   */
+  async handleMessage(message) {
+    const { id, method, params } = message;
+
+    // Handle requests (has id)
+    if (id !== undefined) {
+      try {
+        const result = await this.handleRequest(method, params || {});
+        return { jsonrpc: '2.0', id, result };
+      } catch (error) {
+        return {
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code: -32000,
+            message: error.message
+          }
+        };
+      }
+    }
+
+    // Handle notifications (no id)
+    this.handleNotification(method, params || {});
+    return null;  // Notifications don't return a response
+  }
+
+  /**
+   * Handle a JSON-RPC request
+   */
+  async handleRequest(method, params) {
+    switch (method) {
+      case 'initialize':
+        return this.handleInitialize(params);
+
+      case 'tools/list':
+        return this.handleListTools();
+
+      case 'tools/call':
+        return this.handleCallTool(params);
+
+      case 'ping':
+        return {};
+
+      default:
+        throw new Error(`Unknown method: ${method}`);
+    }
+  }
+
+  /**
+   * Handle notifications
+   */
+  handleNotification(method, params) {
+    switch (method) {
+      case 'notifications/initialized':
+        this.initialized = true;
+        console.error('[MCP Test Server] Received initialized notification');
+        break;
+
+      case 'notifications/cancelled':
+        // Handle cancellation if needed
+        break;
+
+      default:
+        console.error(`[MCP Test Server] Unknown notification: ${method}`);
+    }
+  }
+
+  /**
+   * Handle initialize request
+   */
+  handleInitialize(params) {
+    this.capabilities = {
+      tools: {}
+    };
+
+    return {
+      protocolVersion: '2024-11-05',
+      capabilities: this.capabilities,
+      serverInfo: SERVER_INFO
+    };
+  }
+
+  /**
+   * Handle tools/list request
+   */
+  handleListTools() {
+    return { tools: TOOLS };
+  }
+
+  /**
+   * Handle tools/call request
+   */
+  async handleCallTool(params) {
+    const { name, arguments: args } = params;
+
+    const handler = TOOL_HANDLERS[name];
+    if (!handler) {
+      throw new Error(`Unknown tool: ${name}`);
+    }
+
+    console.error(`[MCP Test Server] Calling tool: ${name}`);
+
+    try {
+      const result = await handler(args || {});
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: ${error.message}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+}
+
+/**
+ * Main entry point
+ */
+async function main() {
+  const server = new MCPServer();
+
+  // Set up readline for stdio communication
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false
+  });
+
+  console.error('[MCP Test Server] Starting...');
+
+  rl.on('line', async (line) => {
+    if (!line.trim()) return;
+
+    try {
+      const message = JSON.parse(line);
+      const response = await server.handleMessage(message);
+
+      if (response !== null) {
+        process.stdout.write(JSON.stringify(response) + '\n');
+      }
+    } catch (error) {
+      console.error('[MCP Test Server] Error processing message:', error.message);
+      // Send error response if we can parse the id
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed.id !== undefined) {
+          const errorResponse = {
+            jsonrpc: '2.0',
+            id: parsed.id,
+            error: {
+              code: -32700,
+              message: 'Parse error'
+            }
+          };
+          process.stdout.write(JSON.stringify(errorResponse) + '\n');
+        }
+      } catch {
+        // Ignore parsing errors for error response
+      }
+    }
+  });
+
+  rl.on('close', () => {
+    console.error('[MCP Test Server] Stdin closed, exiting');
+    process.exit(0);
+  });
+
+  // Handle graceful shutdown
+  process.on('SIGTERM', () => {
+    console.error('[MCP Test Server] Received SIGTERM, shutting down');
+    process.exit(0);
+  });
+
+  process.on('SIGINT', () => {
+    console.error('[MCP Test Server] Received SIGINT, shutting down');
+    process.exit(0);
+  });
+}
+
+main().catch((error) => {
+  console.error('[MCP Test Server] Fatal error:', error);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,18 @@
         "openai": "^4.60.0",
         "pdf-parse": "^1.1.1",
         "pdf2pic": "^3.1.3",
+        "remark": "^15.0.1",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "sentence-splitter": "^5.0.0",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
         "tesseract.js": "^6.0.0",
         "tiktoken": "^1.0.18",
-        "uuid": "^11.0.5"
+        "unist-util-visit": "^5.0.0",
+        "uuid": "^11.0.5",
+        "yaml": "^2.8.2"
       },
       "devDependencies": {
         "mocha": "^11.1.0",
@@ -5073,6 +5080,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@textlint/ast-node-types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz",
+      "integrity": "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ==",
+      "license": "MIT"
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -5088,6 +5101,30 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.19.75",
@@ -5107,6 +5144,12 @@
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.10",
@@ -5340,6 +5383,16 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5470,6 +5523,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/boundary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/bowser": {
       "version": "2.13.1",
@@ -5672,6 +5731,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5700,6 +5769,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -5946,6 +6025,19 @@
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -5995,6 +6087,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -6012,6 +6113,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -6328,6 +6442,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
@@ -6344,6 +6464,19 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/file-type": {
@@ -6542,6 +6675,14 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "license": "MIT"
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
     },
     "node_modules/formdata-node": {
       "version": "4.4.1",
@@ -7366,6 +7507,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lop": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
@@ -7459,6 +7610,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7491,6 +7652,237 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -7517,6 +7909,585 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -8757,6 +9728,87 @@
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "license": "MIT"
     },
+    "node_modules/remark": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
+      "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8902,6 +9954,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/sentence-splitter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-5.0.0.tgz",
+      "integrity": "sha512-9Mvf7L8vwpPzkH0/HtXzCbmVkyj4aQXdeG7h8ighRvO0hvcZEy2OUEjeIlnM/z4EX4vBacEfpESC65Oa2rWOig==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1",
+        "structured-source": "^4.0.0"
       }
     },
     "node_modules/serialize-javascript": {
@@ -9322,6 +10384,15 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/structured-source": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+      "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boundary": "^2.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -9523,6 +10594,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -9587,6 +10668,37 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -9605,6 +10717,61 @@
       "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -9688,6 +10855,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/wasm-feature-detect": {
@@ -9861,6 +11056,21 @@
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -9948,6 +11158,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,18 @@
     "openai": "^4.60.0",
     "pdf-parse": "^1.1.1",
     "pdf2pic": "^3.1.3",
+    "remark": "^15.0.1",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "sentence-splitter": "^5.0.0",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
     "tesseract.js": "^6.0.0",
     "tiktoken": "^1.0.18",
-    "uuid": "^11.0.5"
+    "unist-util-visit": "^5.0.0",
+    "uuid": "^11.0.5",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "mocha": "^11.1.0",

--- a/routes/charmonator/markdown.mjs
+++ b/routes/charmonator/markdown.mjs
@@ -1,0 +1,425 @@
+/**
+ * routes/charmonator/markdown.mjs
+ *
+ * Markdown processing endpoints for Charmonator.
+ * All endpoints are synchronous and deterministic.
+ */
+
+import express from 'express';
+import crypto from 'crypto';
+import {
+  normalizeMarkdown,
+  extractMarkdown,
+  segmentMarkdown,
+  chunkMarkdown,
+  getStrategies,
+  hasStrategy,
+  getSupportedTokenizers
+} from '../../lib/markdown/index.mjs';
+import {
+  isValidEncoding,
+  getSupportedEncodings,
+  resolveTokenizer,
+  resolveTokenizerMode
+} from '../../lib/tokenizer.mjs';
+import { getModelConfig } from '../../lib/config.mjs';
+import { jsonSafeFromException } from '../../lib/providers/provider_exception.mjs';
+
+const router = express.Router();
+
+/**
+ * Resolve encoding from tokenizer/model params for chunking.
+ * For chunking, reject API tokenizer mode (need local encoding).
+ * @param {string} tokenizer - Explicit tokenizer name
+ * @param {string} model - Model name to look up
+ * @returns {{ encoding?: string, error?: string }}
+ */
+function resolveEncodingForChunking(tokenizer, model) {
+  // Mutual exclusivity check
+  if (tokenizer && model) {
+    return { error: 'Cannot specify both "tokenizer" and "model". Use one or the other.' };
+  }
+
+  if (tokenizer) {
+    if (!isValidEncoding(tokenizer)) {
+      const supported = getSupportedEncodings().join(', ');
+      return { error: `Unsupported tokenizer "${tokenizer}". Supported: ${supported}` };
+    }
+    return { encoding: tokenizer };
+  }
+
+  if (model) {
+    try {
+      const modelConfig = getModelConfig(model);
+      const mode = resolveTokenizerMode(modelConfig);
+      if (mode === 'api') {
+        return {
+          error: 'Model uses API tokenizer mode; pass explicit "tokenizer" encoding for deterministic chunking.'
+        };
+      }
+      return { encoding: resolveTokenizer(modelConfig) };
+    } catch (err) {
+      return { error: `Failed to resolve tokenizer for model "${model}": ${err.message}` };
+    }
+  }
+
+  // Default
+  return { encoding: 'cl100k_base' };
+}
+
+/**
+ * GET /strategies
+ *
+ * List supported chunking strategies and their schemas.
+ *
+ * Response:
+ *   {
+ *     "strategies": [...],
+ *     "supported_tokenizers": ["cl100k_base", "o200k_base"]
+ *   }
+ */
+router.get('/strategies', (req, res) => {
+  try {
+    const strategies = getStrategies();
+    const tokenizers = getSupportedTokenizers();
+
+    return res.json({
+      strategies,
+      supported_tokenizers: tokenizers
+    });
+  } catch (err) {
+    const j = jsonSafeFromException(err);
+    console.error({
+      event: 'Error in GET /markdown/strategies',
+      stack: err.stack,
+      errJson: j
+    });
+    res.status(500).json(j);
+  }
+});
+
+/**
+ * POST /normalize
+ *
+ * Normalize markdown in a deterministic way for stable hashing and chunking.
+ *
+ * Request body:
+ *   {
+ *     "markdown": "# Title\r\n\r\nSome text...",
+ *     "options": {
+ *       "line_endings": "lf",
+ *       "trim_trailing_whitespace": true,
+ *       "collapse_multiple_blank_lines": true,
+ *       "ensure_trailing_newline": true,
+ *       "frontmatter": "preserve",
+ *       "obsidian": { "normalize_callouts": true }
+ *     }
+ *   }
+ *
+ * Response:
+ *   {
+ *     "markdown": "# Title\n\nSome text...\n",
+ *     "id": "sha256-of-normalized-markdown"
+ *   }
+ */
+router.post('/normalize', (req, res) => {
+  try {
+    const { markdown, options = {} } = req.body;
+
+    // Validate markdown
+    if (markdown === undefined || markdown === null) {
+      return res.status(400).json({
+        error: 'Field "markdown" is required.'
+      });
+    }
+
+    if (typeof markdown !== 'string') {
+      return res.status(400).json({
+        error: 'Field "markdown" must be a string.'
+      });
+    }
+
+    const result = normalizeMarkdown(markdown, options);
+
+    return res.json(result);
+  } catch (err) {
+    const j = jsonSafeFromException(err);
+    console.error({
+      event: 'Error in POST /markdown/normalize',
+      stack: err.stack,
+      errJson: j
+    });
+    res.status(500).json(j);
+  }
+});
+
+/**
+ * POST /extract
+ *
+ * Extract plain text and metadata from markdown.
+ *
+ * Request body:
+ *   {
+ *     "markdown": "---\ntags: [foo]\n---\n# Title\n\nSee [[Note|alias]]...",
+ *     "options": {
+ *       "frontmatter": "metadata",
+ *       "strip_html": true,
+ *       "preserve_code_blocks": true,
+ *       "obsidian": {
+ *         "wikilinks": "text_only",
+ *         "tags": "metadata_only"
+ *       }
+ *     }
+ *   }
+ *
+ * Response:
+ *   {
+ *     "text": "Title\n\nSee alias...\n",
+ *     "metadata": {
+ *       "frontmatter": { "tags": ["foo"] },
+ *       "tags": ["foo"],
+ *       "links": [...],
+ *       "headings": [...]
+ *     }
+ *   }
+ */
+router.post('/extract', (req, res) => {
+  try {
+    const { markdown, options = {} } = req.body;
+
+    // Validate markdown
+    if (markdown === undefined || markdown === null) {
+      return res.status(400).json({
+        error: 'Field "markdown" is required.'
+      });
+    }
+
+    if (typeof markdown !== 'string') {
+      return res.status(400).json({
+        error: 'Field "markdown" must be a string.'
+      });
+    }
+
+    const result = extractMarkdown(markdown, options);
+
+    return res.json(result);
+  } catch (err) {
+    const j = jsonSafeFromException(err);
+    console.error({
+      event: 'Error in POST /markdown/extract',
+      stack: err.stack,
+      errJson: j
+    });
+    res.status(500).json(j);
+  }
+});
+
+/**
+ * POST /segments
+ *
+ * Segment markdown into atomic units.
+ *
+ * Request body:
+ *   {
+ *     "markdown": "# Title\n\nPara 1.\n\n```js\nconsole.log('hi')\n```\n",
+ *     "strategy": "markdown_blocks",
+ *     "options": {
+ *       "atomic_blocks": ["code", "table", "list_item"]
+ *     }
+ *   }
+ *
+ * Response:
+ *   {
+ *     "segments": [
+ *       { "type": "heading", "depth": 1, "text": "# Title", "span": {...}, "header_path": [...] },
+ *       { "type": "paragraph", "text": "Para 1.", "span": {...}, "header_path": [...] },
+ *       { "type": "code", "language": "js", "text": "...", "span": {...}, "header_path": [...] }
+ *     ]
+ *   }
+ */
+router.post('/segments', (req, res) => {
+  try {
+    const { markdown, strategy = 'markdown_blocks', options = {} } = req.body;
+
+    // Validate markdown
+    if (markdown === undefined || markdown === null) {
+      return res.status(400).json({
+        error: 'Field "markdown" is required.'
+      });
+    }
+
+    if (typeof markdown !== 'string') {
+      return res.status(400).json({
+        error: 'Field "markdown" must be a string.'
+      });
+    }
+
+    // Validate strategy
+    if (!hasStrategy(strategy)) {
+      const available = getStrategies().map(s => s.id).join(', ');
+      return res.status(400).json({
+        error: `Unknown strategy "${strategy}". Available strategies: ${available}`
+      });
+    }
+
+    const segments = segmentMarkdown(markdown, strategy, options);
+
+    return res.json({ segments });
+  } catch (err) {
+    const j = jsonSafeFromException(err);
+    console.error({
+      event: 'Error in POST /markdown/segments',
+      stack: err.stack,
+      errJson: j
+    });
+    res.status(500).json(j);
+  }
+});
+
+/**
+ * POST /chunks
+ *
+ * Chunk markdown into token-bounded chunks.
+ * Returns a Document Object with a new chunk group.
+ *
+ * Request body (Option A - raw markdown):
+ *   {
+ *     "markdown": "# Title\n\nPara 1...\n",
+ *     "strategy": "markdown_headers",
+ *     "max_tokens": 512,
+ *     "overlap_tokens": 64,
+ *     "tokenizer": "cl100k_base",
+ *     "options": { ... },
+ *     "group_name": null
+ *   }
+ *
+ * Request body (Option B - existing document):
+ *   {
+ *     "document": { "id": "...", "content": "..." },
+ *     "strategy": "obsidian",
+ *     "max_tokens": 512,
+ *     ...
+ *   }
+ *
+ * Response:
+ *   {
+ *     "document": { "id": "...", "content": "...", "chunks": {...} },
+ *     "chunk_group": "markdown:markdown_headers(512,cl100k_base,overlap=64)",
+ *     "chunks_created": 5,
+ *     "warnings": []
+ *   }
+ */
+router.post('/chunks', (req, res) => {
+  try {
+    const {
+      markdown,
+      document,
+      strategy = 'markdown_blocks',
+      max_tokens,
+      overlap_tokens = 0,
+      tokenizer,
+      model,
+      options = {},
+      group_name
+    } = req.body;
+
+    // Validate input: need either markdown or document
+    if (!markdown && !document) {
+      return res.status(400).json({
+        error: 'Field "markdown" or "document" is required.'
+      });
+    }
+
+    if (markdown && document) {
+      return res.status(400).json({
+        error: 'Cannot specify both "markdown" and "document". Use one or the other.'
+      });
+    }
+
+    // Get the markdown content
+    let markdownContent;
+    if (markdown) {
+      if (typeof markdown !== 'string') {
+        return res.status(400).json({
+          error: 'Field "markdown" must be a string.'
+        });
+      }
+      markdownContent = markdown;
+    } else {
+      if (!document.content || typeof document.content !== 'string') {
+        return res.status(400).json({
+          error: 'Document must have a "content" field with string value.'
+        });
+      }
+      markdownContent = document.content;
+    }
+
+    // Validate max_tokens
+    if (max_tokens === undefined || max_tokens === null) {
+      return res.status(400).json({
+        error: 'Field "max_tokens" is required.'
+      });
+    }
+
+    if (!Number.isInteger(max_tokens) || max_tokens <= 0) {
+      return res.status(400).json({
+        error: 'Field "max_tokens" must be a positive integer.'
+      });
+    }
+
+    // Validate overlap_tokens
+    if (overlap_tokens !== undefined) {
+      if (!Number.isInteger(overlap_tokens) || overlap_tokens < 0) {
+        return res.status(400).json({
+          error: 'Field "overlap_tokens" must be a non-negative integer.'
+        });
+      }
+
+      if (overlap_tokens >= max_tokens) {
+        return res.status(400).json({
+          error: 'Field "overlap_tokens" must be less than "max_tokens".'
+        });
+      }
+    }
+
+    // Validate strategy
+    if (!hasStrategy(strategy)) {
+      const available = getStrategies().map(s => s.id).join(', ');
+      return res.status(400).json({
+        error: `Unknown strategy "${strategy}". Available strategies: ${available}`
+      });
+    }
+
+    // Resolve encoding
+    const encodingResult = resolveEncodingForChunking(tokenizer, model);
+    if (encodingResult.error) {
+      return res.status(400).json({
+        error: encodingResult.error
+      });
+    }
+
+    const encoding = encodingResult.encoding;
+
+    // Perform chunking
+    const result = chunkMarkdown(markdownContent, {
+      strategy,
+      max_tokens,
+      overlap_tokens,
+      encoding,
+      group_name,
+      strategy_options: options
+    });
+
+    return res.json(result);
+  } catch (err) {
+    const j = jsonSafeFromException(err);
+    console.error({
+      event: 'Error in POST /markdown/chunks',
+      stack: err.stack,
+      errJson: j
+    });
+    res.status(500).json(j);
+  }
+});
+
+export default router;

--- a/routes/charmonator/tools-execute.mjs
+++ b/routes/charmonator/tools-execute.mjs
@@ -1,0 +1,107 @@
+// tools-execute.mjs
+// Endpoint for explicit server/MCP tool execution
+
+import express from 'express';
+import { toolRuntime } from '../../lib/tool-runtime.mjs';
+
+const router = express.Router();
+
+/**
+ * POST /v1/tools/execute
+ *
+ * Execute one or more server/MCP tools explicitly.
+ * This is used by clients to execute server-side tools after receiving
+ * a transcript that ends with client tool calls.
+ *
+ * Request body:
+ * {
+ *   "toolCalls": [
+ *     { "toolName": "calculator", "callId": "call-123", "arguments": { "expression": "2+2" } },
+ *     { "toolName": "web_search", "callId": "call-456", "arguments": { "query": "weather" } }
+ *   ]
+ * }
+ *
+ * Response:
+ * {
+ *   "toolResponses": [
+ *     { "toolName": "calculator", "callId": "call-123", "content": "4" },
+ *     { "toolName": "web_search", "callId": "call-456", "content": "..." }
+ *   ]
+ * }
+ */
+router.post('/execute', async (req, res) => {
+  try {
+    const { toolCalls } = req.body;
+
+    // Validate request
+    if (!toolCalls) {
+      return res.status(400).json({
+        error: 'Missing required field: toolCalls'
+      });
+    }
+
+    if (!Array.isArray(toolCalls)) {
+      return res.status(400).json({
+        error: 'toolCalls must be an array'
+      });
+    }
+
+    // Validate each tool call has required fields
+    for (let i = 0; i < toolCalls.length; i++) {
+      const call = toolCalls[i];
+      if (!call.toolName) {
+        return res.status(400).json({
+          error: `toolCalls[${i}] missing required field: toolName`
+        });
+      }
+      if (!call.callId) {
+        return res.status(400).json({
+          error: `toolCalls[${i}] missing required field: callId`
+        });
+      }
+    }
+
+    console.log(`[ToolsExecute] Executing ${toolCalls.length} tool(s):`,
+      toolCalls.map(tc => tc.toolName).join(', '));
+
+    // Execute the tools
+    const toolResponses = await toolRuntime.executeToolCalls(toolCalls);
+
+    console.log(`[ToolsExecute] Completed. Responses:`,
+      toolResponses.map(tr => tr.error ? `${tr.toolName}:ERROR` : `${tr.toolName}:OK`).join(', '));
+
+    return res.json({ toolResponses });
+  } catch (error) {
+    console.error('[ToolsExecute] Error:', error);
+    return res.status(500).json({
+      error: error.message || 'Internal server error'
+    });
+  }
+});
+
+/**
+ * GET /v1/tools/list
+ *
+ * List all executable (server/MCP) tools.
+ *
+ * Response:
+ * {
+ *   "tools": [
+ *     { "name": "calculator", "description": "...", "input_schema": {...} },
+ *     ...
+ *   ]
+ * }
+ */
+router.get('/list', async (req, res) => {
+  try {
+    const tools = toolRuntime.getExecutableTools();
+    return res.json({ tools });
+  } catch (error) {
+    console.error('[ToolsExecute] Error listing tools:', error);
+    return res.status(500).json({
+      error: error.message || 'Internal server error'
+    });
+  }
+});
+
+export default router;

--- a/routes/tokens.mjs
+++ b/routes/tokens.mjs
@@ -1,0 +1,160 @@
+/**
+ * routes/tokens.mjs
+ *
+ * Token counting and tokenization endpoints.
+ */
+
+import express from 'express';
+import {
+  tokenize,
+  countTokens,
+  isValidEncoding,
+  getSupportedEncodings
+} from '../lib/tokenizer.mjs';
+import { jsonSafeFromException } from '../lib/providers/provider_exception.mjs';
+
+const router = express.Router();
+
+/**
+ * POST /tokens
+ *
+ * Tokenize text and return the token strings.
+ *
+ * Request body:
+ *   {
+ *     "text": "string to tokenize",
+ *     "tokenizer": "cl100k_base",  // optional: explicit tokenizer encoding
+ *     "model": "openai:gpt-4o"     // optional: look up tokenizer from model config
+ *   }
+ *
+ * Note: "tokenizer" and "model" are mutually exclusive. If neither is provided,
+ * defaults to cl100k_base encoding.
+ *
+ * Response:
+ *   {
+ *     "tokens": ["Hello", ",", " world", "!"],
+ *     "count": 4,
+ *     "encoding": "cl100k_base",
+ *     "mode": "local"
+ *   }
+ */
+router.post('/', async (req, res) => {
+  try {
+    const { text, tokenizer, model } = req.body;
+
+    // Validate text
+    if (!text || typeof text !== 'string') {
+      return res.status(400).json({
+        error: 'Field "text" is required and must be a string.'
+      });
+    }
+
+    // Validate mutual exclusivity
+    if (tokenizer && model) {
+      return res.status(400).json({
+        error: 'Cannot specify both "tokenizer" and "model". Use one or the other.'
+      });
+    }
+
+    // Validate tokenizer name if provided
+    if (tokenizer && !isValidEncoding(tokenizer)) {
+      const supported = getSupportedEncodings().join(', ');
+      return res.status(400).json({
+        error: `Unsupported tokenizer "${tokenizer}". Supported: ${supported}`
+      });
+    }
+
+    const result = await tokenize(text, { tokenizer, model });
+
+    return res.json({
+      tokens: result.tokens,
+      count: result.tokens.length,
+      encoding: result.encoding,
+      mode: result.mode
+    });
+  } catch (err) {
+    const j = jsonSafeFromException(err);
+    console.error({
+      event: 'Error in POST /tokens',
+      stack: err.stack,
+      errJson: j
+    });
+    res.status(500).json(j);
+  }
+});
+
+/**
+ * POST /tokens/count
+ *
+ * Count tokens in text without returning the individual tokens.
+ * Supports both local (tiktoken) and API-based counting.
+ *
+ * Request body:
+ *   {
+ *     "text": "string to count tokens in",
+ *     "tokenizer": "cl100k_base",  // optional: explicit tokenizer encoding
+ *     "model": "openai:gpt-4o"     // optional: look up tokenizer from model config
+ *   }
+ *
+ * Note: "tokenizer" and "model" are mutually exclusive. If neither is provided,
+ * defaults to cl100k_base encoding.
+ *
+ * Response (local mode):
+ *   {
+ *     "count": 42,
+ *     "encoding": "cl100k_base",
+ *     "mode": "local"
+ *   }
+ *
+ * Response (API mode):
+ *   {
+ *     "count": 42,
+ *     "encoding": null,
+ *     "mode": "api"
+ *   }
+ */
+router.post('/count', async (req, res) => {
+  try {
+    const { text, tokenizer, model } = req.body;
+
+    // Validate text
+    if (!text || typeof text !== 'string') {
+      return res.status(400).json({
+        error: 'Field "text" is required and must be a string.'
+      });
+    }
+
+    // Validate mutual exclusivity
+    if (tokenizer && model) {
+      return res.status(400).json({
+        error: 'Cannot specify both "tokenizer" and "model". Use one or the other.'
+      });
+    }
+
+    // Validate tokenizer name if provided
+    if (tokenizer && !isValidEncoding(tokenizer)) {
+      const supported = getSupportedEncodings().join(', ');
+      return res.status(400).json({
+        error: `Unsupported tokenizer "${tokenizer}". Supported: ${supported}`
+      });
+    }
+
+    const result = await countTokens(text, { tokenizer, model });
+
+    return res.json({
+      count: result.count,
+      encoding: result.encoding,
+      mode: result.mode
+    });
+  } catch (err) {
+    const j = jsonSafeFromException(err);
+    console.error({
+      event: 'Error in POST /tokens/count',
+      stack: err.stack,
+      errJson: j
+    });
+    res.status(500).json(j);
+  }
+});
+
+export default router;

--- a/routes/transcript-extension.mjs
+++ b/routes/transcript-extension.mjs
@@ -4,6 +4,7 @@ import { fetchChatModel } from '../lib/core.mjs';
 import { TranscriptFragment } from '../lib/transcript.mjs';
 import { FunctionTool } from '../lib/function.mjs';
 import { jsonSafeFromException } from '../lib/providers/provider_exception.mjs';
+import { ToolKind, ToolDefinition } from '../lib/tool-definition.mjs';
 
 const router = express.Router();
 
@@ -20,6 +21,7 @@ router.post('/extension', async (req, res) => {
       temperature,
       transcript: transcriptJson,
       tools,
+      client_tools,  // New: array of client-side tool schemas
       ms_client_request_timeout = null,
       max_attempts = null,
       // New: Accept an "options" object that can contain response_format, stream, etc.
@@ -42,8 +44,7 @@ router.post('/extension', async (req, res) => {
     if (system) chatModel.system = system;
     if (temperature != null) chatModel.temperature = temperature;
 
-    // In case you need to register ephemeral tools:
-    // (Example placeholder; adjust or remove as needed.)
+    // Register ephemeral server tools (legacy, with placeholder implementation)
     if (tools) {
       tools.forEach(toolConfig => {
         const tool = new FunctionTool(async (args) => {
@@ -53,8 +54,25 @@ router.post('/extension', async (req, res) => {
         tool.name = toolConfig.name;
         tool.description = toolConfig.description;
         tool.input_schema = toolConfig.input_schema;
+        tool.kind = ToolKind.SERVER;  // Explicit server kind
         chatModel.addTool(tool);
       });
+    }
+
+    // Register client-side tools (schema only, no server-side execution)
+    if (client_tools && Array.isArray(client_tools)) {
+      client_tools.forEach(toolSchema => {
+        const clientTool = new ToolDefinition({
+          kind: ToolKind.CLIENT,
+          name: toolSchema.name,
+          description: toolSchema.description,
+          input_schema: toolSchema.input_schema,
+          run: undefined,  // Client tools have no server-side run
+          meta: { source: 'request' }
+        });
+        chatModel.addTool(clientTool);
+      });
+      console.log(`[transcript-extension] Registered ${client_tools.length} client tool(s)`);
     }
 
     // Convert incoming transcript to internal format

--- a/tests/fixtures/markdown/code-blocks.md
+++ b/tests/fixtures/markdown/code-blocks.md
@@ -1,0 +1,22 @@
+# Code Examples
+
+Here's a JavaScript function:
+
+```javascript
+function hello(name) {
+  console.log(`Hello, ${name}!`);
+}
+
+hello('World');
+```
+
+And a Python example:
+
+```python
+def greet(name):
+    print(f"Hello, {name}!")
+
+greet("World")
+```
+
+Some text after the code blocks.

--- a/tests/fixtures/markdown/frontmatter-yaml.md
+++ b/tests/fixtures/markdown/frontmatter-yaml.md
@@ -1,0 +1,19 @@
+---
+title: Example Document
+author: Test User
+date: 2024-01-15
+tags:
+  - test
+  - example
+metadata:
+  version: 1.0
+  draft: true
+---
+
+# Document Title
+
+This document has YAML frontmatter with nested metadata.
+
+## Content Section
+
+Main content goes here.

--- a/tests/fixtures/markdown/headings-nested.md
+++ b/tests/fixtures/markdown/headings-nested.md
@@ -1,0 +1,23 @@
+# Main Title
+
+This is an introduction paragraph.
+
+## Section One
+
+Content for section one.
+
+### Subsection 1.1
+
+Details for subsection 1.1.
+
+### Subsection 1.2
+
+Details for subsection 1.2.
+
+## Section Two
+
+Content for section two.
+
+### Subsection 2.1
+
+Details for subsection 2.1.

--- a/tests/fixtures/markdown/obsidian-full.md
+++ b/tests/fixtures/markdown/obsidian-full.md
@@ -1,0 +1,23 @@
+---
+tags: [project, important]
+created: 2024-01-15
+status: active
+---
+
+# Project Notes
+
+This note links to [[Other Note|another note]] and also to [[Simple Link]].
+
+## Tags in Text
+
+This section has #inline-tag and #another-tag embedded in text.
+
+> [!NOTE]
+> This is an Obsidian callout with important information.
+
+> [!WARNING] Be Careful
+> This callout has a custom title.
+
+## More Links
+
+See also: [[Reference Doc]] and [[API Docs|documentation]].

--- a/tests/fixtures/markdown/tables-gfm.md
+++ b/tests/fixtures/markdown/tables-gfm.md
@@ -1,0 +1,11 @@
+# Data Table
+
+Here's a table of data:
+
+| Name | Age | City |
+|------|-----|------|
+| Alice | 30 | New York |
+| Bob | 25 | San Francisco |
+| Carol | 35 | Boston |
+
+Some text after the table.

--- a/tests/test-endpoint-tokens.mjs
+++ b/tests/test-endpoint-tokens.mjs
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+/**
+ * test-endpoint-tokens.mjs
+ *
+ * Tests the /tokens and /tokens/count endpoints.
+ *
+ * Usage: node tests/test-endpoint-tokens.mjs
+ *
+ * Prerequisites: Server must be running (node server.mjs)
+ */
+
+import fetch from 'node-fetch';
+
+const PORT = process.env.CHARMONATOR_PORT || 5002;
+const BASE_PREFIX = process.env.CHARMONATOR_PREFIX || '/charm';
+const BASE_URL = `http://localhost:${PORT}${BASE_PREFIX}/api/charmonator/v1`;
+
+let passed = 0;
+let failed = 0;
+
+function log(message) {
+  console.log(message);
+}
+
+function success(testName) {
+  passed++;
+  console.log(`  [PASS] ${testName}`);
+}
+
+function fail(testName, error) {
+  failed++;
+  console.log(`  [FAIL] ${testName}`);
+  console.log(`         Error: ${error}`);
+}
+
+async function postJson(endpoint, body) {
+  const url = `${BASE_URL}${endpoint}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  const data = await response.json();
+  return { response, data };
+}
+
+async function testServerAvailable() {
+  log('\n=== Checking Server Availability ===');
+  try {
+    const response = await fetch(`${BASE_URL}/models`);
+    if (response.ok) {
+      success('Server is running');
+      return true;
+    } else {
+      fail('Server is running', `Status: ${response.status}`);
+      return false;
+    }
+  } catch (err) {
+    fail('Server is running', `Could not connect to ${BASE_URL}. Is the server running?`);
+    return false;
+  }
+}
+
+// ============================================================
+// POST /tokens tests
+// ============================================================
+
+async function testTokensBasic() {
+  log('\n=== POST /tokens - Basic Tests ===');
+
+  // Test 1: Basic tokenization with default tokenizer
+  try {
+    const { response, data } = await postJson('/tokens', {
+      text: 'Hello, world!'
+    });
+    if (response.ok && Array.isArray(data.tokens) && data.count > 0 && data.encoding === 'cl100k_base') {
+      success('Basic tokenization with default encoding');
+    } else {
+      fail('Basic tokenization with default encoding', JSON.stringify(data));
+    }
+  } catch (err) {
+    fail('Basic tokenization with default encoding', err.message);
+  }
+
+  // Test 2: Tokenization with explicit cl100k_base tokenizer
+  try {
+    const { response, data } = await postJson('/tokens', {
+      text: 'The quick brown fox jumps over the lazy dog.',
+      tokenizer: 'cl100k_base'
+    });
+    if (response.ok && Array.isArray(data.tokens) && data.encoding === 'cl100k_base' && data.mode === 'local') {
+      success('Tokenization with cl100k_base');
+    } else {
+      fail('Tokenization with cl100k_base', JSON.stringify(data));
+    }
+  } catch (err) {
+    fail('Tokenization with cl100k_base', err.message);
+  }
+
+  // Test 3: Tokenization with o200k_base tokenizer
+  try {
+    const { response, data } = await postJson('/tokens', {
+      text: 'Testing with the newer o200k encoding.',
+      tokenizer: 'o200k_base'
+    });
+    if (response.ok && Array.isArray(data.tokens) && data.encoding === 'o200k_base') {
+      success('Tokenization with o200k_base');
+    } else {
+      fail('Tokenization with o200k_base', JSON.stringify(data));
+    }
+  } catch (err) {
+    fail('Tokenization with o200k_base', err.message);
+  }
+
+  // Test 4: Token count matches array length
+  try {
+    const { response, data } = await postJson('/tokens', {
+      text: 'Count should match array length.'
+    });
+    if (response.ok && data.count === data.tokens.length) {
+      success('Token count matches array length');
+    } else {
+      fail('Token count matches array length', `count=${data.count}, tokens.length=${data.tokens?.length}`);
+    }
+  } catch (err) {
+    fail('Token count matches array length', err.message);
+  }
+}
+
+async function testTokensValidation() {
+  log('\n=== POST /tokens - Validation Tests ===');
+
+  // Test 1: Missing text field
+  try {
+    const { response, data } = await postJson('/tokens', {});
+    if (response.status === 400 && data.error) {
+      success('Missing text returns 400');
+    } else {
+      fail('Missing text returns 400', `Status: ${response.status}`);
+    }
+  } catch (err) {
+    fail('Missing text returns 400', err.message);
+  }
+
+  // Test 2: Invalid text type (number)
+  try {
+    const { response, data } = await postJson('/tokens', { text: 12345 });
+    if (response.status === 400 && data.error) {
+      success('Invalid text type returns 400');
+    } else {
+      fail('Invalid text type returns 400', `Status: ${response.status}`);
+    }
+  } catch (err) {
+    fail('Invalid text type returns 400', err.message);
+  }
+
+  // Test 3: Both tokenizer and model provided
+  try {
+    const { response, data } = await postJson('/tokens', {
+      text: 'Test',
+      tokenizer: 'cl100k_base',
+      model: 'some-model'
+    });
+    if (response.status === 400 && data.error && data.error.includes('Cannot specify both')) {
+      success('Both tokenizer and model returns 400');
+    } else {
+      fail('Both tokenizer and model returns 400', `Status: ${response.status}, Error: ${data.error}`);
+    }
+  } catch (err) {
+    fail('Both tokenizer and model returns 400', err.message);
+  }
+
+  // Test 4: Invalid tokenizer name
+  try {
+    const { response, data } = await postJson('/tokens', {
+      text: 'Test',
+      tokenizer: 'invalid_tokenizer'
+    });
+    if (response.status === 400 && data.error && data.error.includes('Unsupported tokenizer')) {
+      success('Invalid tokenizer returns 400');
+    } else {
+      fail('Invalid tokenizer returns 400', `Status: ${response.status}, Error: ${data.error}`);
+    }
+  } catch (err) {
+    fail('Invalid tokenizer returns 400', err.message);
+  }
+}
+
+// ============================================================
+// POST /tokens/count tests
+// ============================================================
+
+async function testTokensCountBasic() {
+  log('\n=== POST /tokens/count - Basic Tests ===');
+
+  // Test 1: Basic count with default tokenizer
+  try {
+    const { response, data } = await postJson('/tokens/count', {
+      text: 'Hello, world!'
+    });
+    if (response.ok && typeof data.count === 'number' && data.count > 0 && data.encoding === 'cl100k_base') {
+      success('Basic count with default encoding');
+    } else {
+      fail('Basic count with default encoding', JSON.stringify(data));
+    }
+  } catch (err) {
+    fail('Basic count with default encoding', err.message);
+  }
+
+  // Test 2: Count with cl100k_base
+  try {
+    const { response, data } = await postJson('/tokens/count', {
+      text: 'The quick brown fox jumps over the lazy dog.',
+      tokenizer: 'cl100k_base'
+    });
+    if (response.ok && typeof data.count === 'number' && data.mode === 'local') {
+      success('Count with cl100k_base');
+    } else {
+      fail('Count with cl100k_base', JSON.stringify(data));
+    }
+  } catch (err) {
+    fail('Count with cl100k_base', err.message);
+  }
+
+  // Test 3: Count with o200k_base
+  try {
+    const { response, data } = await postJson('/tokens/count', {
+      text: 'Testing with the newer o200k encoding.',
+      tokenizer: 'o200k_base'
+    });
+    if (response.ok && typeof data.count === 'number' && data.encoding === 'o200k_base') {
+      success('Count with o200k_base');
+    } else {
+      fail('Count with o200k_base', JSON.stringify(data));
+    }
+  } catch (err) {
+    fail('Count with o200k_base', err.message);
+  }
+
+  // Test 4: Empty string returns 0 tokens
+  try {
+    const { response, data } = await postJson('/tokens/count', {
+      text: ''
+    });
+    // Empty string should still fail validation since we check for truthy text
+    if (response.status === 400) {
+      success('Empty string returns 400');
+    } else if (response.ok && data.count === 0) {
+      success('Empty string returns 0 tokens');
+    } else {
+      fail('Empty string handling', JSON.stringify(data));
+    }
+  } catch (err) {
+    fail('Empty string handling', err.message);
+  }
+}
+
+async function testTokensCountValidation() {
+  log('\n=== POST /tokens/count - Validation Tests ===');
+
+  // Test 1: Missing text field
+  try {
+    const { response, data } = await postJson('/tokens/count', {});
+    if (response.status === 400 && data.error) {
+      success('Missing text returns 400');
+    } else {
+      fail('Missing text returns 400', `Status: ${response.status}`);
+    }
+  } catch (err) {
+    fail('Missing text returns 400', err.message);
+  }
+
+  // Test 2: Both tokenizer and model provided
+  try {
+    const { response, data } = await postJson('/tokens/count', {
+      text: 'Test',
+      tokenizer: 'cl100k_base',
+      model: 'some-model'
+    });
+    if (response.status === 400 && data.error) {
+      success('Both tokenizer and model returns 400');
+    } else {
+      fail('Both tokenizer and model returns 400', `Status: ${response.status}`);
+    }
+  } catch (err) {
+    fail('Both tokenizer and model returns 400', err.message);
+  }
+
+  // Test 3: Invalid tokenizer name
+  try {
+    const { response, data } = await postJson('/tokens/count', {
+      text: 'Test',
+      tokenizer: 'not_a_real_tokenizer'
+    });
+    if (response.status === 400 && data.error) {
+      success('Invalid tokenizer returns 400');
+    } else {
+      fail('Invalid tokenizer returns 400', `Status: ${response.status}`);
+    }
+  } catch (err) {
+    fail('Invalid tokenizer returns 400', err.message);
+  }
+}
+
+// ============================================================
+// Consistency tests
+// ============================================================
+
+async function testConsistency() {
+  log('\n=== Consistency Tests ===');
+
+  // Test 1: /tokens and /tokens/count return same count
+  try {
+    const text = 'This is a test sentence for consistency checking.';
+    const { data: tokensData } = await postJson('/tokens', { text, tokenizer: 'cl100k_base' });
+    const { data: countData } = await postJson('/tokens/count', { text, tokenizer: 'cl100k_base' });
+
+    if (tokensData.count === countData.count) {
+      success('/tokens and /tokens/count return same count');
+    } else {
+      fail('/tokens and /tokens/count return same count',
+           `tokens.count=${tokensData.count}, count.count=${countData.count}`);
+    }
+  } catch (err) {
+    fail('/tokens and /tokens/count return same count', err.message);
+  }
+
+  // Test 2: Different encodings can produce different token counts
+  try {
+    const text = 'Testing different encodings for the same text.';
+    const { data: cl100k } = await postJson('/tokens/count', { text, tokenizer: 'cl100k_base' });
+    const { data: o200k } = await postJson('/tokens/count', { text, tokenizer: 'o200k_base' });
+
+    // They might be the same or different, but both should be valid counts
+    if (typeof cl100k.count === 'number' && typeof o200k.count === 'number') {
+      success(`Different encodings produce valid counts (cl100k=${cl100k.count}, o200k=${o200k.count})`);
+    } else {
+      fail('Different encodings produce valid counts', 'Invalid count values');
+    }
+  } catch (err) {
+    fail('Different encodings produce valid counts', err.message);
+  }
+
+  // Test 3: Unicode text tokenization
+  try {
+    const text = 'Hello, \u4e16\u754c! Emoji: \ud83d\ude00\ud83d\udc4d';
+    const { response, data } = await postJson('/tokens', { text });
+    if (response.ok && Array.isArray(data.tokens) && data.count > 0) {
+      success('Unicode and emoji tokenization works');
+    } else {
+      fail('Unicode and emoji tokenization works', JSON.stringify(data));
+    }
+  } catch (err) {
+    fail('Unicode and emoji tokenization works', err.message);
+  }
+
+  // Test 4: Long text tokenization
+  try {
+    const text = 'word '.repeat(1000);
+    const { response, data } = await postJson('/tokens/count', { text });
+    if (response.ok && data.count >= 1000) {
+      success(`Long text tokenization works (${data.count} tokens)`);
+    } else {
+      fail('Long text tokenization works', JSON.stringify(data));
+    }
+  } catch (err) {
+    fail('Long text tokenization works', err.message);
+  }
+}
+
+// ============================================================
+// Main
+// ============================================================
+
+async function runTests() {
+  console.log('===========================================');
+  console.log('  Charmonator /tokens Endpoint Tests');
+  console.log('===========================================');
+  console.log(`Server: ${BASE_URL}`);
+
+  const serverUp = await testServerAvailable();
+  if (!serverUp) {
+    console.log('\nServer is not available. Please start the server first:');
+    console.log('  node server.mjs');
+    process.exit(1);
+  }
+
+  await testTokensBasic();
+  await testTokensValidation();
+  await testTokensCountBasic();
+  await testTokensCountValidation();
+  await testConsistency();
+
+  console.log('\n===========================================');
+  console.log('  Test Results');
+  console.log('===========================================');
+  console.log(`  Passed: ${passed}`);
+  console.log(`  Failed: ${failed}`);
+  console.log(`  Total:  ${passed + failed}`);
+  console.log('===========================================\n');
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+runTests().catch(err => {
+  console.error('Test runner error:', err);
+  process.exit(1);
+});

--- a/tests/test-markdown-chunks.mjs
+++ b/tests/test-markdown-chunks.mjs
@@ -1,0 +1,195 @@
+/**
+ * tests/test-markdown-chunks.mjs
+ *
+ * Tests for markdown chunking functionality.
+ */
+
+import { chunkMarkdown, generateGroupName, generateChunkId } from '../lib/markdown/chunk.mjs';
+import { getStrategies, hasStrategy } from '../lib/markdown/strategies/index.mjs';
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+console.log('Running markdown chunking tests...\n');
+
+// Test 1: Basic chunking
+{
+  console.log('Test 1: Basic chunking');
+  const input = '# Title\n\nThis is a paragraph of text.\n\n## Section\n\nMore content here.\n';
+  const result = chunkMarkdown(input, {
+    strategy: 'markdown_blocks',
+    max_tokens: 100,
+    encoding: 'cl100k_base'
+  });
+  assert.ok(result.document, 'Should have document');
+  assert.ok(result.document.id, 'Document should have ID');
+  assert.ok(result.chunks_created > 0, 'Should create at least one chunk');
+  console.log(`  Created ${result.chunks_created} chunks`);
+  console.log('  PASSED\n');
+}
+
+// Test 2: Group name generation
+{
+  console.log('Test 2: Group name generation');
+  const groupName = generateGroupName('markdown_headers', 512, 'cl100k_base', 64);
+  assert.strictEqual(groupName, 'markdown:markdown_headers(512,cl100k_base,overlap=64)');
+  console.log(`  Group name: ${groupName}`);
+  console.log('  PASSED\n');
+}
+
+// Test 3: Chunk ID generation
+{
+  console.log('Test 3: Chunk ID generation');
+  const chunkId = generateChunkId('parent123', 'group:test', 0);
+  assert.strictEqual(chunkId, 'parent123/group:test@0');
+  console.log(`  Chunk ID: ${chunkId}`);
+  console.log('  PASSED\n');
+}
+
+// Test 4: Document structure
+{
+  console.log('Test 4: Document structure');
+  const input = '# Title\n\nContent.\n';
+  const result = chunkMarkdown(input, {
+    strategy: 'markdown_blocks',
+    max_tokens: 100
+  });
+  assert.ok(result.document.content, 'Document should have content');
+  assert.ok(result.document.metadata, 'Document should have metadata');
+  assert.ok(result.document.chunks, 'Document should have chunks');
+  assert.strictEqual(result.document.metadata.mimetype, 'text/markdown');
+  console.log('  PASSED\n');
+}
+
+// Test 5: Chunk metadata
+{
+  console.log('Test 5: Chunk metadata');
+  const input = '# Section\n\nParagraph of text here.\n';
+  const result = chunkMarkdown(input, {
+    strategy: 'markdown_blocks',
+    max_tokens: 100
+  });
+  const chunks = result.document.chunks[result.chunk_group];
+  assert.ok(chunks.length > 0, 'Should have chunks');
+  const chunk = chunks[0];
+  assert.ok(chunk.id, 'Chunk should have ID');
+  assert.ok(chunk.parent, 'Chunk should have parent');
+  assert.ok(chunk.content, 'Chunk should have content');
+  assert.ok(chunk.metadata, 'Chunk should have metadata');
+  assert.ok(typeof chunk.metadata.chunk_index === 'number', 'Should have chunk_index');
+  assert.ok(typeof chunk.metadata.token_count === 'number', 'Should have token_count');
+  console.log(`  First chunk token count: ${chunk.metadata.token_count}`);
+  console.log('  PASSED\n');
+}
+
+// Test 6: No chunk exceeds max_tokens
+{
+  console.log('Test 6: No chunk exceeds max_tokens');
+  const fixturePath = path.join(__dirname, 'fixtures/markdown/headings-nested.md');
+  const input = fs.readFileSync(fixturePath, 'utf8');
+  const maxTokens = 50;
+  const result = chunkMarkdown(input, {
+    strategy: 'markdown_blocks',
+    max_tokens: maxTokens
+  });
+  const chunks = result.document.chunks[result.chunk_group];
+  for (const chunk of chunks) {
+    assert.ok(
+      chunk.metadata.token_count <= maxTokens * 1.5, // Allow some tolerance for edge cases
+      `Chunk ${chunk.id} has ${chunk.metadata.token_count} tokens, expected <= ${maxTokens}`
+    );
+  }
+  console.log(`  All ${chunks.length} chunks within token limit`);
+  console.log('  PASSED\n');
+}
+
+// Test 7: Sliding window strategy
+{
+  console.log('Test 7: Sliding window strategy');
+  const input = 'This is a test. '.repeat(20);
+  const result = chunkMarkdown(input, {
+    strategy: 'sliding_window',
+    max_tokens: 30,
+    overlap_tokens: 10
+  });
+  assert.ok(result.chunks_created > 1, 'Should create multiple chunks');
+  console.log(`  Created ${result.chunks_created} sliding window chunks`);
+  console.log('  PASSED\n');
+}
+
+// Test 8: Recursive separators strategy
+{
+  console.log('Test 8: Recursive separators strategy');
+  const input = 'Paragraph one.\n\nParagraph two.\n\nParagraph three.\n';
+  const result = chunkMarkdown(input, {
+    strategy: 'recursive_separators',
+    max_tokens: 20
+  });
+  assert.ok(result.chunks_created > 0, 'Should create chunks');
+  console.log(`  Created ${result.chunks_created} recursive separator chunks`);
+  console.log('  PASSED\n');
+}
+
+// Test 9: All strategies available
+{
+  console.log('Test 9: All strategies available');
+  const strategies = getStrategies();
+  const expectedStrategies = [
+    'markdown_headers',
+    'markdown_blocks',
+    'recursive_separators',
+    'sliding_window',
+    'sentence_pack',
+    'obsidian'
+  ];
+  for (const id of expectedStrategies) {
+    assert.ok(hasStrategy(id), `Strategy ${id} should be available`);
+  }
+  console.log(`  All ${expectedStrategies.length} strategies available`);
+  console.log('  PASSED\n');
+}
+
+// Test 10: Deterministic chunking
+{
+  console.log('Test 10: Deterministic chunking');
+  const input = '# Title\n\nContent here.\n';
+  const result1 = chunkMarkdown(input, { strategy: 'markdown_blocks', max_tokens: 100 });
+  const result2 = chunkMarkdown(input, { strategy: 'markdown_blocks', max_tokens: 100 });
+  assert.strictEqual(result1.document.id, result2.document.id, 'Document IDs should match');
+  assert.strictEqual(result1.chunk_group, result2.chunk_group, 'Chunk groups should match');
+  assert.strictEqual(result1.chunks_created, result2.chunks_created, 'Chunk counts should match');
+  console.log('  PASSED\n');
+}
+
+// Test 11: Custom group name
+{
+  console.log('Test 11: Custom group name');
+  const input = '# Title\n\nContent.\n';
+  const result = chunkMarkdown(input, {
+    strategy: 'markdown_blocks',
+    max_tokens: 100,
+    group_name: 'custom_group'
+  });
+  assert.strictEqual(result.chunk_group, 'custom_group');
+  assert.ok(result.document.chunks['custom_group'], 'Should use custom group name');
+  console.log('  PASSED\n');
+}
+
+// Test 12: Obsidian strategy with fixture
+{
+  console.log('Test 12: Obsidian strategy with fixture');
+  const fixturePath = path.join(__dirname, 'fixtures/markdown/obsidian-full.md');
+  const input = fs.readFileSync(fixturePath, 'utf8');
+  const result = chunkMarkdown(input, {
+    strategy: 'obsidian',
+    max_tokens: 100
+  });
+  assert.ok(result.chunks_created > 0, 'Should create chunks');
+  console.log(`  Created ${result.chunks_created} obsidian chunks`);
+  console.log('  PASSED\n');
+}
+
+console.log('All chunking tests passed!');

--- a/tests/test-markdown-extract.mjs
+++ b/tests/test-markdown-extract.mjs
@@ -1,0 +1,106 @@
+/**
+ * tests/test-markdown-extract.mjs
+ *
+ * Tests for markdown text and metadata extraction.
+ */
+
+import { extractMarkdown } from '../lib/markdown/extract.mjs';
+import assert from 'assert';
+
+console.log('Running markdown extraction tests...\n');
+
+// Test 1: Basic text extraction
+{
+  console.log('Test 1: Basic text extraction');
+  const input = '# Title\n\nThis is a paragraph.\n';
+  const result = extractMarkdown(input);
+  assert.ok(result.text.includes('Title'), 'Should extract heading text');
+  assert.ok(result.text.includes('paragraph'), 'Should extract paragraph text');
+  console.log('  PASSED\n');
+}
+
+// Test 2: Frontmatter extraction as metadata
+{
+  console.log('Test 2: Frontmatter extraction as metadata');
+  const input = '---\ntitle: Test\ntags:\n  - foo\n  - bar\n---\n\n# Heading\n';
+  const result = extractMarkdown(input, { frontmatter: 'metadata' });
+  assert.ok(result.metadata.frontmatter, 'Should have frontmatter in metadata');
+  assert.strictEqual(result.metadata.frontmatter.title, 'Test', 'Should extract title');
+  assert.deepStrictEqual(result.metadata.frontmatter.tags, ['foo', 'bar'], 'Should extract tags');
+  console.log('  PASSED\n');
+}
+
+// Test 3: Frontmatter drop
+{
+  console.log('Test 3: Frontmatter drop');
+  const input = '---\ntitle: Test\n---\n\n# Heading\n';
+  const result = extractMarkdown(input, { frontmatter: 'drop' });
+  assert.strictEqual(result.metadata.frontmatter, undefined, 'Should not have frontmatter');
+  console.log('  PASSED\n');
+}
+
+// Test 4: Wikilink extraction
+{
+  console.log('Test 4: Wikilink extraction');
+  const input = 'See [[Other Note|alias]] and [[Simple Link]].\n';
+  const result = extractMarkdown(input);
+  assert.ok(result.metadata.links, 'Should have links in metadata');
+  assert.strictEqual(result.metadata.links.length, 2, 'Should have 2 links');
+  assert.strictEqual(result.metadata.links[0].target, 'Other Note', 'Should extract link target');
+  assert.strictEqual(result.metadata.links[0].text, 'alias', 'Should extract link alias');
+  console.log('  PASSED\n');
+}
+
+// Test 5: Wikilink text_only processing
+{
+  console.log('Test 5: Wikilink text_only processing');
+  const input = 'See [[Other Note|alias]] here.\n';
+  const result = extractMarkdown(input, { obsidian: { wikilinks: 'text_only' } });
+  assert.ok(result.text.includes('alias'), 'Should include alias text');
+  assert.ok(!result.text.includes('[['), 'Should not include wikilink syntax');
+  console.log('  PASSED\n');
+}
+
+// Test 6: Tag extraction
+{
+  console.log('Test 6: Tag extraction');
+  const input = 'This has #tag1 and #tag2 in the text.\n';
+  const result = extractMarkdown(input);
+  assert.ok(result.metadata.tags, 'Should have tags in metadata');
+  assert.ok(result.metadata.tags.includes('tag1'), 'Should extract tag1');
+  assert.ok(result.metadata.tags.includes('tag2'), 'Should extract tag2');
+  console.log('  PASSED\n');
+}
+
+// Test 7: Heading extraction
+{
+  console.log('Test 7: Heading extraction');
+  const input = '# Main\n\n## Sub1\n\n### Sub2\n';
+  const result = extractMarkdown(input);
+  assert.ok(result.metadata.headings, 'Should have headings in metadata');
+  assert.strictEqual(result.metadata.headings.length, 3, 'Should have 3 headings');
+  assert.strictEqual(result.metadata.headings[0].depth, 1, 'First heading should be depth 1');
+  assert.strictEqual(result.metadata.headings[0].text, 'Main', 'Should extract heading text');
+  console.log('  PASSED\n');
+}
+
+// Test 8: Code block preservation
+{
+  console.log('Test 8: Code block preservation');
+  const input = '```js\nconst x = 1;\n```\n';
+  const result = extractMarkdown(input, { preserve_code_blocks: true });
+  assert.ok(result.text.includes('const x = 1'), 'Should preserve code block content');
+  console.log('  PASSED\n');
+}
+
+// Test 9: Combined tags from frontmatter and text
+{
+  console.log('Test 9: Combined tags from frontmatter and text');
+  const input = '---\ntags: [frontmatter-tag]\n---\n\nText with #inline-tag\n';
+  const result = extractMarkdown(input, { frontmatter: 'metadata' });
+  assert.ok(result.metadata.tags.includes('frontmatter-tag'), 'Should have frontmatter tag');
+  assert.ok(result.metadata.tags.includes('inline-tag'), 'Should have inline tag');
+  console.log('  PASSED\n');
+}
+
+console.log('All extraction tests passed!');

--- a/tests/test-markdown-normalize.mjs
+++ b/tests/test-markdown-normalize.mjs
@@ -1,0 +1,105 @@
+/**
+ * tests/test-markdown-normalize.mjs
+ *
+ * Tests for markdown normalization functionality.
+ */
+
+import { normalizeMarkdown } from '../lib/markdown/normalize.mjs';
+import assert from 'assert';
+
+console.log('Running markdown normalization tests...\n');
+
+// Test 1: Line ending normalization (CRLF -> LF)
+{
+  console.log('Test 1: Line ending normalization (CRLF -> LF)');
+  const input = '# Title\r\n\r\nParagraph\r\n';
+  const result = normalizeMarkdown(input, { line_endings: 'lf' });
+  assert.strictEqual(result.markdown, '# Title\n\nParagraph\n');
+  assert.ok(result.id, 'Should have an ID');
+  console.log('  PASSED\n');
+}
+
+// Test 2: Line ending normalization (LF -> CRLF)
+{
+  console.log('Test 2: Line ending normalization (LF -> CRLF)');
+  const input = '# Title\n\nParagraph\n';
+  const result = normalizeMarkdown(input, { line_endings: 'crlf' });
+  assert.strictEqual(result.markdown, '# Title\r\n\r\nParagraph\r\n');
+  console.log('  PASSED\n');
+}
+
+// Test 3: Trailing whitespace trimming
+{
+  console.log('Test 3: Trailing whitespace trimming');
+  const input = '# Title   \n\nParagraph  \n';
+  const result = normalizeMarkdown(input, { trim_trailing_whitespace: true });
+  assert.strictEqual(result.markdown, '# Title\n\nParagraph\n');
+  console.log('  PASSED\n');
+}
+
+// Test 4: Multiple blank line collapsing
+{
+  console.log('Test 4: Multiple blank line collapsing');
+  const input = '# Title\n\n\n\nParagraph\n';
+  const result = normalizeMarkdown(input, { collapse_multiple_blank_lines: true });
+  assert.strictEqual(result.markdown, '# Title\n\nParagraph\n');
+  console.log('  PASSED\n');
+}
+
+// Test 5: Ensure trailing newline
+{
+  console.log('Test 5: Ensure trailing newline');
+  const input = '# Title\n\nParagraph';
+  const result = normalizeMarkdown(input, { ensure_trailing_newline: true });
+  assert.ok(result.markdown.endsWith('\n'), 'Should end with newline');
+  console.log('  PASSED\n');
+}
+
+// Test 6: Frontmatter preservation
+{
+  console.log('Test 6: Frontmatter preservation');
+  const input = '---\ntitle: Test\n---\n\n# Title\n';
+  const result = normalizeMarkdown(input, { frontmatter: 'preserve' });
+  assert.ok(result.markdown.includes('---\ntitle: Test\n---'), 'Should preserve frontmatter');
+  console.log('  PASSED\n');
+}
+
+// Test 7: Frontmatter dropping
+{
+  console.log('Test 7: Frontmatter dropping');
+  const input = '---\ntitle: Test\n---\n\n# Title\n';
+  const result = normalizeMarkdown(input, { frontmatter: 'drop' });
+  assert.ok(!result.markdown.includes('---'), 'Should not contain frontmatter');
+  assert.ok(result.markdown.includes('# Title'), 'Should still have content');
+  console.log('  PASSED\n');
+}
+
+// Test 8: Deterministic ID generation
+{
+  console.log('Test 8: Deterministic ID generation');
+  const input = '# Title\n\nParagraph\n';
+  const result1 = normalizeMarkdown(input);
+  const result2 = normalizeMarkdown(input);
+  assert.strictEqual(result1.id, result2.id, 'Same input should produce same ID');
+  console.log('  PASSED\n');
+}
+
+// Test 9: Different content produces different IDs
+{
+  console.log('Test 9: Different content produces different IDs');
+  const result1 = normalizeMarkdown('# Title A\n');
+  const result2 = normalizeMarkdown('# Title B\n');
+  assert.notStrictEqual(result1.id, result2.id, 'Different content should produce different IDs');
+  console.log('  PASSED\n');
+}
+
+// Test 10: Obsidian callout normalization
+{
+  console.log('Test 10: Obsidian callout normalization');
+  const input = '> [!note] My Title\n> Content\n';
+  const result = normalizeMarkdown(input, { obsidian: { normalize_callouts: true } });
+  assert.ok(result.markdown.includes('[!NOTE]'), 'Should normalize callout type to uppercase');
+  console.log('  PASSED\n');
+}
+
+console.log('All normalization tests passed!');

--- a/tests/test-markdown-segments.mjs
+++ b/tests/test-markdown-segments.mjs
@@ -1,0 +1,128 @@
+/**
+ * tests/test-markdown-segments.mjs
+ *
+ * Tests for markdown segmentation functionality.
+ */
+
+import { segmentMarkdown, segmentByBlocks, segmentByHeaders } from '../lib/markdown/segment.mjs';
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+console.log('Running markdown segmentation tests...\n');
+
+// Test 1: Basic block segmentation
+{
+  console.log('Test 1: Basic block segmentation');
+  const input = '# Title\n\nParagraph one.\n\nParagraph two.\n';
+  const segments = segmentMarkdown(input, 'markdown_blocks');
+  assert.ok(segments.length >= 3, 'Should have at least 3 segments (heading + 2 paragraphs)');
+  assert.ok(segments.some(s => s.type === 'heading'), 'Should have heading segment');
+  assert.ok(segments.some(s => s.type === 'paragraph'), 'Should have paragraph segments');
+  console.log(`  Found ${segments.length} segments`);
+  console.log('  PASSED\n');
+}
+
+// Test 2: Code block segmentation
+{
+  console.log('Test 2: Code block segmentation');
+  const input = '# Code\n\n```js\nconsole.log("hi");\n```\n';
+  const segments = segmentMarkdown(input, 'markdown_blocks');
+  const codeSegment = segments.find(s => s.type === 'code');
+  assert.ok(codeSegment, 'Should have code segment');
+  assert.strictEqual(codeSegment.language, 'js', 'Should capture language');
+  console.log('  PASSED\n');
+}
+
+// Test 3: Header path tracking
+{
+  console.log('Test 3: Header path tracking');
+  const input = '# Main\n\n## Sub\n\nContent\n';
+  const segments = segmentMarkdown(input, 'markdown_blocks');
+  const contentSegment = segments.find(s => s.type === 'paragraph');
+  assert.ok(contentSegment, 'Should have paragraph segment');
+  assert.ok(Array.isArray(contentSegment.header_path), 'Should have header_path array');
+  console.log(`  Header path: ${JSON.stringify(contentSegment.header_path)}`);
+  console.log('  PASSED\n');
+}
+
+// Test 4: Line span tracking
+{
+  console.log('Test 4: Line span tracking');
+  const input = '# Title\n\nParagraph\n';
+  const segments = segmentMarkdown(input, 'markdown_blocks');
+  const heading = segments.find(s => s.type === 'heading');
+  assert.ok(heading.span, 'Should have span');
+  assert.ok(heading.span.start_line >= 1, 'Should have valid start_line');
+  assert.ok(heading.span.end_line >= heading.span.start_line, 'end_line should be >= start_line');
+  console.log(`  Heading span: lines ${heading.span.start_line}-${heading.span.end_line}`);
+  console.log('  PASSED\n');
+}
+
+// Test 5: Header-based segmentation
+{
+  console.log('Test 5: Header-based segmentation');
+  const input = '# Section 1\n\nContent 1.\n\n# Section 2\n\nContent 2.\n';
+  const segments = segmentByHeaders(input, { include_headers_in_chunk: true });
+  assert.ok(segments.length >= 2, 'Should have at least 2 sections');
+  console.log(`  Found ${segments.length} sections`);
+  console.log('  PASSED\n');
+}
+
+// Test 6: List segmentation
+{
+  console.log('Test 6: List segmentation');
+  const input = '# List\n\n- Item 1\n- Item 2\n- Item 3\n';
+  const segments = segmentMarkdown(input, 'markdown_blocks');
+  const listSegment = segments.find(s => s.type === 'list' || s.type === 'list_item');
+  assert.ok(listSegment, 'Should have list segment');
+  console.log(`  List segment type: ${listSegment.type}`);
+  console.log('  PASSED\n');
+}
+
+// Test 7: Table segmentation
+{
+  console.log('Test 7: Table segmentation');
+  const input = '# Data\n\n| A | B |\n|---|---|\n| 1 | 2 |\n';
+  const segments = segmentMarkdown(input, 'markdown_blocks');
+  const tableSegment = segments.find(s => s.type === 'table');
+  assert.ok(tableSegment, 'Should have table segment');
+  console.log('  PASSED\n');
+}
+
+// Test 8: Frontmatter handling
+{
+  console.log('Test 8: Frontmatter handling');
+  const input = '---\ntitle: Test\n---\n\n# Title\n';
+  const segments = segmentMarkdown(input, 'markdown_blocks');
+  const frontmatterSegment = segments.find(s => s.type === 'frontmatter');
+  assert.ok(frontmatterSegment, 'Should have frontmatter segment');
+  console.log('  PASSED\n');
+}
+
+// Test 9: Nested headings fixture
+{
+  console.log('Test 9: Nested headings fixture file');
+  const fixturePath = path.join(__dirname, 'fixtures/markdown/headings-nested.md');
+  const input = fs.readFileSync(fixturePath, 'utf8');
+  const segments = segmentMarkdown(input, 'markdown_blocks');
+  const headings = segments.filter(s => s.type === 'heading');
+  assert.ok(headings.length >= 5, 'Should have multiple heading segments');
+  console.log(`  Found ${headings.length} headings in fixture`);
+  console.log('  PASSED\n');
+}
+
+// Test 10: Deterministic output
+{
+  console.log('Test 10: Deterministic output');
+  const input = '# Title\n\nParagraph.\n';
+  const segments1 = segmentMarkdown(input, 'markdown_blocks');
+  const segments2 = segmentMarkdown(input, 'markdown_blocks');
+  assert.deepStrictEqual(segments1, segments2, 'Same input should produce identical segments');
+  console.log('  PASSED\n');
+}
+
+console.log('All segmentation tests passed!');

--- a/tests/test-mcp-server.mjs
+++ b/tests/test-mcp-server.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * test-mcp-server.mjs
+ *
+ * Tests the MCP test server functionality.
+ */
+
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(__dirname, '../mcp-servers/test-server.mjs');
+
+let requestId = 0;
+
+function sendRequest(proc, method, params) {
+  return new Promise((resolve, reject) => {
+    const id = ++requestId;
+    const request = { jsonrpc: '2.0', id, method, params };
+
+    let responseData = '';
+
+    const onData = (data) => {
+      responseData += data.toString();
+      const lines = responseData.split('\n');
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const response = JSON.parse(line);
+          if (response.id === id) {
+            proc.stdout.off('data', onData);
+            if (response.error) {
+              reject(new Error(response.error.message));
+            } else {
+              resolve(response.result);
+            }
+            return;
+          }
+        } catch (e) {
+          // Partial JSON, continue buffering
+        }
+      }
+    };
+
+    proc.stdout.on('data', onData);
+
+    setTimeout(() => {
+      proc.stdout.off('data', onData);
+      reject(new Error('Request timeout'));
+    }, 5000);
+
+    proc.stdin.write(JSON.stringify(request) + '\n');
+  });
+}
+
+function sendNotification(proc, method, params) {
+  const notification = { jsonrpc: '2.0', method, params };
+  proc.stdin.write(JSON.stringify(notification) + '\n');
+}
+
+async function runTests() {
+  console.log('Starting MCP test server...');
+
+  const proc = spawn('node', [serverPath], {
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  proc.stderr.on('data', (data) => {
+    console.log('[Server stderr]', data.toString().trim());
+  });
+
+  try {
+    // Test 1: Initialize
+    console.log('\n=== Test 1: Initialize ===');
+    const initResult = await sendRequest(proc, 'initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: { tools: {} },
+      clientInfo: { name: 'test-client', version: '1.0.0' }
+    });
+    console.log('Init result:', JSON.stringify(initResult, null, 2));
+
+    sendNotification(proc, 'notifications/initialized', {});
+
+    // Test 2: List tools
+    console.log('\n=== Test 2: List Tools ===');
+    const listResult = await sendRequest(proc, 'tools/list', {});
+    console.log('Tools:', listResult.tools.map(t => t.name).join(', '));
+
+    // Test 3: Echo tool
+    console.log('\n=== Test 3: Echo Tool ===');
+    const echoResult = await sendRequest(proc, 'tools/call', {
+      name: 'echo',
+      arguments: { message: 'Hello, MCP!' }
+    });
+    console.log('Echo result:', echoResult.content[0].text);
+
+    // Test 4: Calculator - add
+    console.log('\n=== Test 4: Calculator Add ===');
+    const addResult = await sendRequest(proc, 'tools/call', {
+      name: 'calculator',
+      arguments: { operation: 'add', a: 5, b: 3 }
+    });
+    console.log('Add result:', addResult.content[0].text);
+
+    // Test 5: Calculator - multiply
+    console.log('\n=== Test 5: Calculator Multiply ===');
+    const mulResult = await sendRequest(proc, 'tools/call', {
+      name: 'calculator',
+      arguments: { operation: 'multiply', a: 7, b: 6 }
+    });
+    console.log('Multiply result:', mulResult.content[0].text);
+
+    // Test 6: Calculator - divide by zero
+    console.log('\n=== Test 6: Calculator Divide by Zero ===');
+    const divZeroResult = await sendRequest(proc, 'tools/call', {
+      name: 'calculator',
+      arguments: { operation: 'divide', a: 10, b: 0 }
+    });
+    console.log('Divide by zero result:', divZeroResult.content[0].text);
+    console.log('isError:', divZeroResult.isError);
+
+    // Test 7: Write file
+    console.log('\n=== Test 7: Write File ===');
+    const writeResult = await sendRequest(proc, 'tools/call', {
+      name: 'write_file',
+      arguments: { filename: 'test.txt', content: 'Hello from MCP test!' }
+    });
+    console.log('Write result:', writeResult.content[0].text);
+
+    // Test 8: Read file (the one we just wrote)
+    console.log('\n=== Test 8: Read File ===');
+    const writeData = JSON.parse(writeResult.content[0].text);
+    const readResult = await sendRequest(proc, 'tools/call', {
+      name: 'read_file',
+      arguments: { path: writeData.path }
+    });
+    console.log('Read result:', readResult.content[0].text);
+
+    console.log('\n=== All tests passed! ===');
+
+  } catch (error) {
+    console.error('Test failed:', error);
+    process.exitCode = 1;
+  } finally {
+    proc.kill('SIGTERM');
+  }
+}
+
+runTests();


### PR DESCRIPTION
I refactored tool-handling and cleaned it up the back ends.  Now, you can use very simple toolboxes or MCPs, or designate client-side tools.

I also created a number of charmonator endpoints for advanced markdown chunking techniques, usefully as a precursor to RAG.

This shouldn't break any existing functionality (unless it depended on tool-calling).