### PR TITLE
Add writing prompts for humans to describe charmonator PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+# Title (For title field)
+_What does this PR accomplish?_
+
+_Example: “Fix crash on login for users with legacy tokens”_
+
+# Description
+## Type of PR
+_Bug, Feature, Breaking change, Documentation, other._
+
+## What this PR does
+_In 2–3 sentences…_
+
+## The problem this solves
+_What problem we’re solving or behavior we’re improving…_
+
+## How to verify/test
+_Include steps or commands…_
+
+## Related issues/design docs
+_Link to any relevant tickets or RFCs…_
+
+## Feedback requested
+_Design? Tests? Security? Performance?_
+
+## Any additional testing requested
+_Describe percieved risks and how they might be mitigated_
+
+## Maturity
+_Note if this is preliminatory, proposed, final, or retroactive._
+
+## Reviewers requested
+_Name specific individuals.  Or assign specific asks to specific individuals._
+
+## LLM Artifacts
+_Please attach any LLM artifacts that might help illuminate the intention of this change_
+


### PR DESCRIPTION
Merging this PR will cause all PRs in this project to be pre-populated with these writing prompts for humans.

All the prompts should be interpreted as optional food for thought as opposed to something required, but if something is dumb let's fix it before we teach ourselves to ignore it.  It's much harder to stop ignoring something once you've tuned it out.

If we do a good job with these PR descriptions, we may also be able to harvest a good "release notes" by summarizing what we've written with an LLM to fit a release notes form factor.  Also to consider, when approving a PR through the UI, it is easy to copy-paste the github description in to the merge commit text for an in-repository record.

Since everything else might be LLM authored, I feel like it might be good to have a ground rule that answers to these prompts need to be your own human writing out of your brain without an LLM.  It's better for it to read badly or be missing stuff than for it to be regurgitating an unintended misleading part of what got generated into the PR itself.

I co-created the prompts with chatgpt.  Though I have made significant manual revisions, reading the chat might possibly shed some light on what I am getting at here.  [Full Chat](https://chatgpt.com/share/696e9d87-7368-800a-98f8-0e5107ac0254)

Matt, please review.
